### PR TITLE
Add message representation

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,5 @@
+machine:
+  python:
+    version: 3.4.4
+    
+  

--- a/singer/__init__.py
+++ b/singer/__init__.py
@@ -21,12 +21,13 @@ class Message(object):
         return self.asdict() == other.asdict()
 
     def __repr__(self):
-        attrstr = ", ".join("{}={}".format(k, getattr(self, k)) for k in self.attr_list)
+        attrstr = ", ".join(
+            "{}={}".format(k, getattr(self, k)) for k in self.attr_list)
         return "{}({})".format(self.__class__.__name__, attrstr)
-    
+
     def tojson(self):
         return json.dumps(self.asdict())
-    
+
 
 class RecordMessage(Message):
     _type = 'RECORD'
@@ -41,7 +42,7 @@ class SchemaMessage(Message):
 class StateMessage(Message):
     _type = 'STATE'
     attr_list = ['value']
-    
+
 
 def to_json(message):
     m = vars(message)
@@ -92,7 +93,11 @@ def write_schema(stream_name, schema, key_properties):
         key_properties = [key_properties]
     if not isinstance(key_properties, list):
         raise Exception("key_properties must be a string or list of strings")
-    _write_message(SchemaMessage(stream=stream_name, schema=schema, key_properties=key_properties))
+    _write_message(
+        SchemaMessage(
+            stream=stream_name,
+            schema=schema,
+            key_properties=key_properties))
 
 
 def write_state(value):

--- a/singer/__init__.py
+++ b/singer/__init__.py
@@ -4,9 +4,27 @@ import os
 import logging
 import logging.config
 
+from collections import namedtuple
 
-def _writeline(message):
-    sys.stdout.write(s + '\n')
+RecordMessage = namedtuple('RecordMessage', ['stream', 'record'])
+SchemaMessage = namedtuple('SchemaMessage', ['stream', 'schema', 'key_properties'])
+StateMessage = namedtuple('StateMessage', ['value'])
+
+def to_json(message):
+    m = message.__dict__.copy()
+    if isinstance(message, RecordMessage):
+        m['type'] = 'RECORD'
+    elif isinstance(message, SchemaMessage):
+        m['type'] = 'SCHEMA'
+    elif isinstance(message, StateMessage):
+        m['type'] = 'STATE'
+    else:
+        raise Exception('Unrecognized message {}'.format(message))
+    return json.dumps(m)
+
+
+def _write_message(message):
+    sys.stdout.write(to_json(message) + '\n')
     sys.stdout.flush()
 
 
@@ -15,7 +33,7 @@ def write_record(stream_name, record):
 
     >>> write_record("users", {"id": 2, "email": "mike@stitchdata.com"})
     """
-    RecordMessage(stream_name, record).write(sys.stdout)
+    _write_message(RecordMessage(stream_name, record))
 
 
 def write_records(stream_name, records):
@@ -37,7 +55,11 @@ def write_schema(stream_name, schema, key_properties):
     >>> key_properties = ['id']
     >>> write_schema(stream, schema, key_properties)
     """
-    SchemaMessage(stream_name, schema, key_properties).write(sys.stdout)
+    if isinstance(key_properties, (str, bytes)):
+        key_properties = [key_properties]
+    if not isinstance(key_properties, list):
+        raise Exception("key_properties must be a string or list of strings")
+    _write_message(SchemaMessage(stream_name, schema, key_properties))
 
 
 def write_state(value):
@@ -45,23 +67,18 @@ def write_state(value):
 
     >>> write_state({'last_updated_at': '2017-02-14T09:21:00'})
     """
-    StateMessage(value).write(sys.stdout)
+    _write_message(StateMessage(value))
 
 
 def _required_key(msg, k):
     if k not in msg:
         raise Exception("Message is missing required key '{}': {}".format(k, msg))
-    return msg['k']
+    return msg[k]
 
 
 def parse_message(s):
     """Parse a message string into a Message object."""
-    try:
-        o = json.loads(s)
-    except json.decoder.JSONDecodeError:
-        logger.error("Unable to parse:\n{}".format(s))
-        raise
-
+    o = json.loads(s)
     t = _required_key(o, 'type')
 
     if t == 'RECORD':
@@ -75,57 +92,6 @@ def parse_message(s):
     
     elif t == 'STATE':
         return StateMessage(_required_key(o, 'value'))
-
-
-class Message(object):
-    '''Base class for messages.'''
-    def write(self, stream):
-        sys.stdout.write(self.to_json())
-        sys.stdout.flush()
-
-
-class RecordMessage(Message):
-    '''Represents a RECORD message.'''
-    def __init__(self, stream, record):
-        self.stream = stream
-        self.record = record
-
-    def to_json(self):
-        return json.dumps({'type': 'RECORD',
-                           'stream': self.stream,
-                           'record': self.record})
-                           
-
-class SchemaMessage(Message):
-    '''Represents a SCHEMA message.'''    
-    def __init__(self, stream, schema, key_properties):
-        if isinstance(key_properties, (str, bytes)):
-            key_properties = [key_properties]
-        if not isinstance(key_properties, list):
-            raise Exception("key_properties must be a string or list of strings")
-        
-        self.stream = stream
-        self.schema = schema
-        self.key_properties = key_properties
-
-
-class StateMessage(Message):
-    '''Represents a STATE message.'''
-    def __init__(self, value):
-        self.value = value
-
-
-class Validator(object):
-    def __init__(self, schema, key_properties):
-        self.schema = schema
-        self.key_properties = key_properties
-        self.validator = Draft4Validator(schema, format_checker=FormatChecker())
-                                         
-    def validate(self, record):
-        for k in key_properties:
-            if k not in record:
-                raise Exception('Missing key property {}'.format(k))
-        self.validator.validate(record)
 
 
 def get_logger():

--- a/singer/__init__.py
+++ b/singer/__init__.py
@@ -15,7 +15,7 @@ StateMessage = namedtuple('StateMessage', ['value'])
 
 
 def to_json(message):
-    m = message.__dict__.copy()
+    m = vars(message)
     if isinstance(message, RecordMessage):
         m['type'] = 'RECORD'
     elif isinstance(message, SchemaMessage):

--- a/singer/__init__.py
+++ b/singer/__init__.py
@@ -7,8 +7,12 @@ import logging.config
 from collections import namedtuple
 
 RecordMessage = namedtuple('RecordMessage', ['stream', 'record'])
-SchemaMessage = namedtuple('SchemaMessage', ['stream', 'schema', 'key_properties'])
+
+SchemaMessage = namedtuple('SchemaMessage',
+                           ['stream', 'schema', 'key_properties'])
+
 StateMessage = namedtuple('StateMessage', ['value'])
+
 
 def to_json(message):
     m = message.__dict__.copy()
@@ -72,7 +76,8 @@ def write_state(value):
 
 def _required_key(msg, k):
     if k not in msg:
-        raise Exception("Message is missing required key '{}': {}".format(k, msg))
+        raise Exception("Message is missing required key '{}': {}".format(
+            k, msg))
     return msg[k]
 
 
@@ -89,7 +94,7 @@ def parse_message(s):
         return SchemaMessage(_required_key(o, 'stream'),
                              _required_key(o, 'schema'),
                              _required_key(o, 'key_properties'))
-    
+
     elif t == 'STATE':
         return StateMessage(_required_key(o, 'value'))
 

--- a/singer/__init__.py
+++ b/singer/__init__.py
@@ -4,15 +4,44 @@ import os
 import logging
 import logging.config
 
-from collections import namedtuple
 
-RecordMessage = namedtuple('RecordMessage', ['stream', 'record'])
+class Message(object):
+    def __init__(self, **kwargs):
+        for k in self.attr_list:
+            if k not in kwargs:
+                raise ValueError("missing {}".format(k))
+            setattr(self, k, kwargs[k])
 
-SchemaMessage = namedtuple('SchemaMessage',
-                           ['stream', 'schema', 'key_properties'])
+    def asdict(self):
+        res = {k: getattr(self, k) for k in self.attr_list}
+        res['type'] = self._type
+        return res
 
-StateMessage = namedtuple('StateMessage', ['value'])
+    def __eq__(self, other):
+        return self.asdict() == other.asdict()
 
+    def __repr__(self):
+        attrstr = ", ".join("{}={}".format(k, getattr(self, k)) for k in self.attr_list)
+        return "{}({})".format(self.__class__.__name__, attrstr)
+    
+    def tojson(self):
+        return json.dumps(self.asdict())
+    
+
+class RecordMessage(Message):
+    _type = 'RECORD'
+    attr_list = ['stream', 'record']
+
+
+class SchemaMessage(Message):
+    _type = 'SCHEMA'
+    attr_list = ['stream', 'schema', 'key_properties']
+
+
+class StateMessage(Message):
+    _type = 'STATE'
+    attr_list = ['value']
+    
 
 def to_json(message):
     m = vars(message)
@@ -37,7 +66,7 @@ def write_record(stream_name, record):
 
     >>> write_record("users", {"id": 2, "email": "mike@stitchdata.com"})
     """
-    _write_message(RecordMessage(stream_name, record))
+    _write_message(RecordMessage(stream=stream_name, record=record))
 
 
 def write_records(stream_name, records):
@@ -63,7 +92,7 @@ def write_schema(stream_name, schema, key_properties):
         key_properties = [key_properties]
     if not isinstance(key_properties, list):
         raise Exception("key_properties must be a string or list of strings")
-    _write_message(SchemaMessage(stream_name, schema, key_properties))
+    _write_message(SchemaMessage(stream=stream_name, schema=schema, key_properties=key_properties))
 
 
 def write_state(value):
@@ -87,16 +116,16 @@ def parse_message(s):
     t = _required_key(o, 'type')
 
     if t == 'RECORD':
-        return RecordMessage(_required_key(o, 'stream'),
-                             _required_key(o, 'record'))
+        return RecordMessage(stream=_required_key(o, 'stream'),
+                             record=_required_key(o, 'record'))
 
     elif t == 'SCHEMA':
-        return SchemaMessage(_required_key(o, 'stream'),
-                             _required_key(o, 'schema'),
-                             _required_key(o, 'key_properties'))
+        return SchemaMessage(stream=_required_key(o, 'stream'),
+                             schema=_required_key(o, 'schema'),
+                             key_properties=_required_key(o, 'key_properties'))
 
     elif t == 'STATE':
-        return StateMessage(_required_key(o, 'value'))
+        return StateMessage(value=_required_key(o, 'value'))
 
 
 def get_logger():

--- a/tests/test_singer.py
+++ b/tests/test_singer.py
@@ -4,8 +4,11 @@ import unittest
 
 class TestSinger(unittest.TestCase):
     def test_parse_message_record_good(self):
-        message = singer.parse_message('{"type": "RECORD", "record": {"name": "foo"}, "stream": "users"}')
-        self.assertEqual(message, singer.RecordMessage(record={'name': 'foo'}, stream='users'))
+        message = singer.parse_message(
+            '{"type": "RECORD", "record": {"name": "foo"}, "stream": "users"}')
+        self.assertEqual(
+            message,
+            singer.RecordMessage(record={'name': 'foo'}, stream='users'))
 
     def test_parse_message_record_missing_record(self):
         with self.assertRaises(Exception):
@@ -13,10 +16,11 @@ class TestSinger(unittest.TestCase):
 
     def test_parse_message_record_missing_stream(self):
         with self.assertRaises(Exception):
-            singer.parse_message('{"type": "RECORD", "record": {"name": "foo"}}')
+            singer.parse_message(
+                '{"type": "RECORD", "record": {"name": "foo"}}')
 
     def test_parse_message_schema_good(self):
-        message = singer.parse_message('{"type": "SCHEMA", "stream": "users", "schema": {"type": "object", "properties": {"name": {"type": "string"}}}, "key_properties": ["name"]}')
+        message = singer.parse_message('{"type": "SCHEMA", "stream": "users", "schema": {"type": "object", "properties": {"name": {"type": "string"}}}, "key_properties": ["name"]}')  # nopep8
         self.assertEqual(
             message,
             singer.SchemaMessage(
@@ -28,18 +32,20 @@ class TestSinger(unittest.TestCase):
 
     def test_parse_message_schema_missing_stream(self):
         with self.assertRaises(Exception):
-            message = singer.parse_message('{"type": "SCHEMA", "schema": {"type": "object", "properties": {"name": {"type": "string"}}}, "key_properties": ["name"]}')
+            message = singer.parse_message('{"type": "SCHEMA", "schema": {"type": "object", "properties": {"name": {"type": "string"}}}, "key_properties": ["name"]}')  # nopep8
 
     def test_parse_message_schema_missing_schema(self):
         with self.assertRaises(Exception):
-            message = singer.parse_message('{"type": "SCHEMA", "stream": "users", "key_properties": ["name"]}')
+            message = singer.parse_message(
+                '{"type": "SCHEMA", "stream": "users", "key_properties": ["name"]}')  # nopep8
 
     def test_parse_message_schema_missing_key_properties(self):
         with self.assertRaises(Exception):
-            message = singer.parse_message('{"type": "SCHEMA", "stream": "users", "schema": {"type": "object", "properties": {"name": {"type": "string"}}}}')
+            message = singer.parse_message('{"type": "SCHEMA", "stream": "users", "schema": {"type": "object", "properties": {"name": {"type": "string"}}}}')  # nopep8
 
     def test_parse_message_state_good(self):
-        message = singer.parse_message('{"type": "STATE", "value": {"seq": 1}}')
+        message = singer.parse_message(
+            '{"type": "STATE", "value": {"seq": 1}}')
         self.assertEqual(message, singer.StateMessage({'seq': 1}))
 
     def test_parse_message_state_missing_value(self):
@@ -51,7 +57,7 @@ class TestSinger(unittest.TestCase):
         record_message = singer.RecordMessage(
             record={'name': 'foo'},
             stream='users')
-        
+
         schema_message = singer.SchemaMessage(
             stream='users',
             key_properties=['name'],
@@ -66,8 +72,8 @@ class TestSinger(unittest.TestCase):
         self.assertEquals(schema_message,
                           singer.parse_message(singer.to_json(schema_message)))
         self.assertEquals(state_message,
-                          singer.parse_message(singer.to_json(state_message)))                
-            
-        
+                          singer.parse_message(singer.to_json(state_message)))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_singer.py
+++ b/tests/test_singer.py
@@ -67,12 +67,12 @@ class TestSinger(unittest.TestCase):
 
         state_message = singer.StateMessage(value={'seq': 1})
 
-        self.assertEquals(record_message,
-                          singer.parse_message(singer.to_json(record_message)))
-        self.assertEquals(schema_message,
-                          singer.parse_message(singer.to_json(schema_message)))
-        self.assertEquals(state_message,
-                          singer.parse_message(singer.to_json(state_message)))
+        self.assertEqual(record_message,
+                         singer.parse_message(singer.to_json(record_message)))
+        self.assertEqual(schema_message,
+                         singer.parse_message(singer.to_json(schema_message)))
+        self.assertEqual(state_message,
+                         singer.parse_message(singer.to_json(state_message)))
 
 
 if __name__ == '__main__':

--- a/tests/test_singer.py
+++ b/tests/test_singer.py
@@ -1,0 +1,73 @@
+import singer
+import unittest
+
+
+class TestSinger(unittest.TestCase):
+    def test_parse_message_record_good(self):
+        message = singer.parse_message('{"type": "RECORD", "record": {"name": "foo"}, "stream": "users"}')
+        self.assertEqual(message, singer.RecordMessage(record={'name': 'foo'}, stream='users'))
+
+    def test_parse_message_record_missing_record(self):
+        with self.assertRaises(Exception):
+            singer.parse_message('{"type": "RECORD", "stream": "users"}')
+
+    def test_parse_message_record_missing_stream(self):
+        with self.assertRaises(Exception):
+            singer.parse_message('{"type": "RECORD", "record": {"name": "foo"}}')
+
+    def test_parse_message_schema_good(self):
+        message = singer.parse_message('{"type": "SCHEMA", "stream": "users", "schema": {"type": "object", "properties": {"name": {"type": "string"}}}, "key_properties": ["name"]}')
+        self.assertEqual(
+            message,
+            singer.SchemaMessage(
+                stream='users',
+                key_properties=['name'],
+                schema={'type': 'object',
+                        'properties': {
+                            'name': {'type': 'string'}}}))
+
+    def test_parse_message_schema_missing_stream(self):
+        with self.assertRaises(Exception):
+            message = singer.parse_message('{"type": "SCHEMA", "schema": {"type": "object", "properties": {"name": {"type": "string"}}}, "key_properties": ["name"]}')
+
+    def test_parse_message_schema_missing_schema(self):
+        with self.assertRaises(Exception):
+            message = singer.parse_message('{"type": "SCHEMA", "stream": "users", "key_properties": ["name"]}')
+
+    def test_parse_message_schema_missing_key_properties(self):
+        with self.assertRaises(Exception):
+            message = singer.parse_message('{"type": "SCHEMA", "stream": "users", "schema": {"type": "object", "properties": {"name": {"type": "string"}}}}')
+
+    def test_parse_message_state_good(self):
+        message = singer.parse_message('{"type": "STATE", "value": {"seq": 1}}')
+        self.assertEqual(message, singer.StateMessage({'seq': 1}))
+
+    def test_parse_message_state_missing_value(self):
+        with self.assertRaises(Exception):
+            singer.parse_message('{"type": "STATE"}')
+
+    def test_round_trip(self):
+
+        record_message = singer.RecordMessage(
+            record={'name': 'foo'},
+            stream='users')
+        
+        schema_message = singer.SchemaMessage(
+            stream='users',
+            key_properties=['name'],
+            schema={'type': 'object',
+                    'properties': {
+                        'name': {'type': 'string'}}})
+
+        state_message = singer.StateMessage({'seq': 1})
+
+        self.assertEquals(record_message,
+                          singer.parse_message(singer.to_json(record_message)))
+        self.assertEquals(schema_message,
+                          singer.parse_message(singer.to_json(schema_message)))
+        self.assertEquals(state_message,
+                          singer.parse_message(singer.to_json(state_message)))                
+            
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_singer.py
+++ b/tests/test_singer.py
@@ -46,7 +46,7 @@ class TestSinger(unittest.TestCase):
     def test_parse_message_state_good(self):
         message = singer.parse_message(
             '{"type": "STATE", "value": {"seq": 1}}')
-        self.assertEqual(message, singer.StateMessage({'seq': 1}))
+        self.assertEqual(message, singer.StateMessage(value={'seq': 1}))
 
     def test_parse_message_state_missing_value(self):
         with self.assertRaises(Exception):
@@ -65,7 +65,7 @@ class TestSinger(unittest.TestCase):
                     'properties': {
                         'name': {'type': 'string'}}})
 
-        state_message = singer.StateMessage({'seq': 1})
+        state_message = singer.StateMessage(value={'seq': 1})
 
         self.assertEquals(record_message,
                           singer.parse_message(singer.to_json(record_message)))


### PR DESCRIPTION
As we start to add more targets, we'll want a common way to parse output from taps. This adds a `singer.parse_message` function that takes a JSON line and returns an object that represents the message.

* Add three new namedtuple classes to represent message data.
  * RecordMessage
  * SchemaMessage
  * StateMessage
* Convert the write_record, write_schema, and write_state functions to use those classes.
* Add a parse_message function that takes a string and returns an instance of one of the message classes.
* Add unit tests