### PR TITLE
Add --properties and --discover args

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import subprocess
 
 
 setup(name="singer-python",
-      version="0.2.2",
+      version="0.3.0",
       description="Singer.io utility library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -74,6 +74,7 @@ def parse_args(required_config_keys):
     parser = argparse.ArgumentParser()
     parser.add_argument('-c', '--config', help='Config file', required=True)
     parser.add_argument('-s', '--state', help='State file')
+    parser.add_argument('-p', '--properties', help='Property selections')
     args = parser.parse_args()
 
     config = load_json(args.config)
@@ -84,7 +85,12 @@ def parse_args(required_config_keys):
     else:
         state = {}
 
-    return config, state
+    if args.properties:
+        properties = load_json(args.properties)
+    else:
+        properties = {}
+        
+    return config, state, properties
 
 
 def check_config(config, required_keys):

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -72,25 +72,36 @@ def update_state(state, entity, dtime):
 
 def parse_args(required_config_keys):
     parser = argparse.ArgumentParser()
-    parser.add_argument('-c', '--config', help='Config file', required=True)
-    parser.add_argument('-s', '--state', help='State file')
-    parser.add_argument('-p', '--properties', help='Property selections')
+
+    parser.add_argument(
+        '-c', '--config',
+        help='Config file',
+        required=True)
+
+    parser.add_argument(
+        '-s', '--state',
+        help='State file')
+
+    parser.add_argument(
+        '-p', '--properties',
+        help='Property selections')
+
+    parser.add_argument(
+        '-d', '--discover',
+        action='store_true',
+        help='Do schema discovery')
+
     args = parser.parse_args()
-
-    config = load_json(args.config)
-    check_config(config, required_config_keys)
-
+    if args.config:
+        args.config = load_json(args.config)
     if args.state:
-        state = load_json(args.state)
-    else:
-        state = {}
-
+        args.state = load_json(args.state)
     if args.properties:
-        properties = load_json(args.properties)
-    else:
-        properties = {}
-        
-    return config, state, properties
+        args.properties = load_json(args.properties)
+    
+    check_config(args.config, required_config_keys)
+
+    return args
 
 
 def check_config(config, required_keys):

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -110,6 +110,8 @@ def parse_args(required_config_keys):
         args.config = load_json(args.config)
     if args.state:
         args.state = load_json(args.state)
+    else:
+        args.state = {}
     if args.properties:
         args.properties = load_json(args.properties)
 

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -98,7 +98,7 @@ def parse_args(required_config_keys):
         args.state = load_json(args.state)
     if args.properties:
         args.properties = load_json(args.properties)
-    
+
     check_config(args.config, required_config_keys)
 
     return args

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -71,6 +71,20 @@ def update_state(state, entity, dtime):
 
 
 def parse_args(required_config_keys):
+    '''Parse standard command-line args.
+
+    Parses the command-line arguments mentioned in the SPEC and the
+    BEST_PRACTICES documents:
+
+    -c,--config     Config file
+    -s,--state      State file
+    -d,--discover   Run in discover mode
+    -p,--properties Properties file
+
+    Returns the parsed args object from argparse. For each argument that
+    point to JSON files (config, state, properties), we will automatically
+    load and parse the JSON file.
+    '''
     parser = argparse.ArgumentParser()
 
     parser.add_argument(


### PR DESCRIPTION
Add two more args to the parse_args function. The function used to return a tuple of two args, (config, state). Now we just return the args object that is returned by argparse.

This is what we're using for tap-facebook.

I'll bump the major version before releasing, since this is a breaking change to parse_args.