### PR TITLE
Remove two fns

### DIFF
--- a/singer/utils.py
+++ b/singer/utils.py
@@ -3,7 +3,6 @@ import collections
 import datetime
 import functools
 import json
-import os
 import time
 
 DATETIME_FMT = "%Y-%m-%dT%H:%M:%SZ"

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -43,17 +43,9 @@ def chunk(array, num):
         yield array[i:i + num]
 
 
-def get_abs_path(path):
-    return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
-
-
 def load_json(path):
     with open(path) as fil:
         return json.load(fil)
-
-
-def load_schema(entity):
-    return load_json(get_abs_path("schemas/{}.json".format(entity)))
 
 
 def update_state(state, entity, dtime):


### PR DESCRIPTION
Remove load_schema and get_abs_path. load_schema('foo') is supposed to load the 'foo.json' file in the 'schema' directory. It does so by looking at the absolute path of __file__. In this case, that will be the absolute path of singer/utils.py, not the absolute path of the Tap that is calling this library fn. It doesn't make much sense for these functions to exist in this common library, and they've caused confusion for Tap authors.