### PR TITLE
Add object models for Schema and Catalog

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="singer-python",
-      version='1.6.0',
+      version='1.7.0',
       description="Singer.io utility library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/singer/catalog.py
+++ b/singer/catalog.py
@@ -1,0 +1,62 @@
+@attr.s
+class CatalogEntry(object):
+    replication_key = attr.ib(default=None)
+    key_properties = attr.ib(default=None)
+    schema = attr.ib(default=None)
+    is_view = attr.ib(default=None)
+    database = attr.ib(default=None)
+    table = attr.ib(default=None)
+    stream = attr.ib(default=None)
+    row_count = attr.ib(default=None)
+
+    def is_selected(self):
+        return self.schema.selected  # pylint: disable=no-member
+
+    def to_dict(self):
+        result = {
+            'database': self.database,
+            'table': self.table,
+        }
+        if self.replication_key is not None:
+            result['replication_key'] = self.replication_key
+        if self.key_properties is not None:
+            result['key_properties'] = self.key_properties
+        if self.schema is not None:
+            result['schema'] = self.schema.to_json() # pylint: disable=no-member
+        if self.is_view is not None:
+            result['is_view'] = self.is_view
+        if self.stream is not None:
+            result['stream'] = self.stream
+        if self.row_count is not None:
+            result['row_count'] = self.row_count
+        return result
+
+@attr.s
+class Catalog(object):
+
+    streams = attr.ib()
+    
+    def load(filename):
+        with open(filename) as fp:
+            return Catalog.from_dict(json.load(fp))
+
+    @classmethod
+    def from_dict(self, data):
+        streams = []
+        for stream in data['streams']:
+            streams.append(
+                CatalogEntry(
+                    replication_key=stream.get('replication_key'),
+                    key_properties=stream.get('key_properties'),
+                    database=stream.get('database'),
+                    table=stream.get('table'),
+                    schema=Schema.from_dict(stream.get('schema')),
+                    is_view=stream.get('is_view')))
+        return Catalog(streams)
+        
+        
+    def to_dict(self):
+        return {'streams': [stream.to_json() for stream in self.streams]}
+    
+    def dump(self):
+        json.dump(self.to_dict(), sys.stdout, indent=2)

--- a/singer/catalog.py
+++ b/singer/catalog.py
@@ -5,12 +5,13 @@ import sys
 
 from singer.schema import Schema
 
+
 # pylint: disable=too-many-instance-attributes
 class CatalogEntry(object):
 
     def __init__(self, tap_stream_id=None, stream=None,
-                 key_properties=None, schema=None, replication_key=None, is_view=None,
-                 database=None, table=None, row_count=None):
+                 key_properties=None, schema=None, replication_key=None,
+                 is_view=None, database=None, table=None, row_count=None):
 
         self.tap_stream_id = tap_stream_id
         self.stream = stream
@@ -44,7 +45,8 @@ class CatalogEntry(object):
         if self.key_properties is not None:
             result['key_properties'] = self.key_properties
         if self.schema is not None:
-            result['schema'] = self.schema.to_dict() # pylint: disable=no-member
+            schema = self.schema.to_dict()  # pylint: disable=no-member
+            result['schema'] = schema
         if self.is_view is not None:
             result['is_view'] = self.is_view
         if self.stream is not None:
@@ -52,6 +54,7 @@ class CatalogEntry(object):
         if self.row_count is not None:
             result['row_count'] = self.row_count
         return result
+
 
 class Catalog(object):
 
@@ -66,7 +69,7 @@ class Catalog(object):
 
     @classmethod
     def load(cls, filename):
-        with open(filename) as fp: # pylint: disable=invalid-name
+        with open(filename) as fp:  # pylint: disable=invalid-name
             return Catalog.from_dict(json.load(fp))
 
     @classmethod
@@ -84,7 +87,6 @@ class Catalog(object):
             entry.is_view = stream.get('is_view')
             streams.append(entry)
         return Catalog(streams)
-
 
     def to_dict(self):
         return {'streams': [stream.to_dict() for stream in self.streams]}

--- a/singer/catalog.py
+++ b/singer/catalog.py
@@ -1,21 +1,27 @@
 '''Provides an object model for a Singer Catalog.'''
 
-import attr
 import json
 
 from singer.schema import Schema
 
-@attr.s
 class CatalogEntry(object):
-    tap_stream_id = attr.ib(default=None)
-    replication_key = attr.ib(default=None)
-    key_properties = attr.ib(default=None)
-    schema = attr.ib(default=None)
-    is_view = attr.ib(default=None)
-    database = attr.ib(default=None)
-    table = attr.ib(default=None)
-    stream = attr.ib(default=None)
-    row_count = attr.ib(default=None)
+
+    def __init__(self, tap_stream_id=None, stream=None, key_properties=None, schema=None, replication_key=None, is_view=None, database=None, table=None, row_count=None):
+        self.tap_stream_id = tap_stream_id
+        self.stream = stream
+        self.key_properties = key_properties
+        self.schema = schema
+        self.replication_key = replication_key
+        self.is_view = is_view
+        self.database = database
+        self.table = table
+        self.row_count = row_count
+
+    def __str__(self):
+        return str(self.__dict__)
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
 
     def is_selected(self):
         return self.schema.selected  # pylint: disable=no-member
@@ -42,10 +48,16 @@ class CatalogEntry(object):
             result['row_count'] = self.row_count
         return result
 
-@attr.s
 class Catalog(object):
 
-    streams = attr.ib()
+    def __init__(self, streams):
+        self.streams = streams
+
+    def __str__(self):
+        return str(self.__dict__)
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
     
     def load(filename):
         with open(filename) as fp:

--- a/singer/catalog.py
+++ b/singer/catalog.py
@@ -1,12 +1,17 @@
 '''Provides an object model for a Singer Catalog.'''
 
 import json
+import sys
 
 from singer.schema import Schema
 
+# pylint: disable=too-many-instance-attributes
 class CatalogEntry(object):
 
-    def __init__(self, tap_stream_id=None, stream=None, key_properties=None, schema=None, replication_key=None, is_view=None, database=None, table=None, row_count=None):
+    def __init__(self, tap_stream_id=None, stream=None,
+                 key_properties=None, schema=None, replication_key=None, is_view=None,
+                 database=None, table=None, row_count=None):
+
         self.tap_stream_id = tap_stream_id
         self.stream = stream
         self.key_properties = key_properties
@@ -58,18 +63,19 @@ class Catalog(object):
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
-    
-    def load(filename):
-        with open(filename) as fp:
+
+    @classmethod
+    def load(cls, filename):
+        with open(filename) as fp: # pylint: disable=invalid-name
             return Catalog.from_dict(json.load(fp))
 
     @classmethod
-    def from_dict(self, data):
+    def from_dict(cls, data):
         streams = []
         for stream in data['streams']:
             entry = CatalogEntry()
             entry.tap_stream_id = stream.get('tap_stream_id')
-            entry.stream = stream.get('stream')            
+            entry.stream = stream.get('stream')
             entry.replication_key = stream.get('replication_key')
             entry.key_properties = stream.get('key_properties')
             entry.database = stream.get('database_name')
@@ -82,6 +88,6 @@ class Catalog(object):
 
     def to_dict(self):
         return {'streams': [stream.to_dict() for stream in self.streams]}
-    
+
     def dump(self):
         json.dump(self.to_dict(), sys.stdout, indent=2)

--- a/singer/schema.py
+++ b/singer/schema.py
@@ -1,3 +1,5 @@
+'''Provides an object model for JSON Schema'''
+
 import json
 import attr
 
@@ -52,7 +54,7 @@ class Schema(object):
                 k: v.to_dict() for k, v in self.properties.items() # pylint: disable=no-member
             }
         if self.items:
-            result['items'] = self.items.to_dict()
+            result['items'] = self.items.to_dict() # pylint: disable=no-member
         for key in STANDARD_KEYS:
             if self.__dict__[key] is not None:
                 result[key] = self.__dict__[key]
@@ -60,12 +62,12 @@ class Schema(object):
         return result
 
     @classmethod
-    def from_dict(self, data):
+    def from_dict(cls, data):
         '''Initialize a Schema object based on the raw JSON Schema data structure.'''
         kwargs = {}
         properties = data.get('properties')
         items = data.get('items')
-        
+
         if properties:
             kwargs['properties'] = {
                 k: Schema.from_dict(v) for k, v in properties.items()
@@ -76,4 +78,3 @@ class Schema(object):
             if key in data:
                 kwargs[key] = data[key]
         return Schema(**kwargs)
-

--- a/singer/schema.py
+++ b/singer/schema.py
@@ -41,14 +41,14 @@ class Schema(object):
     format = attr.ib(default=None)
 
     def __str__(self):
-        return json.dumps(self.to_json())
+        return json.dumps(self.to_dict())
 
-    def to_json(self):
+    def to_dict(self):
         '''Return the raw JSON Schema as a (possibly nested) dict.'''
         result = {}
         if self.properties:
             result['properties'] = {
-                k: v.to_json() for k, v in self.properties.items() # pylint: disable=no-member
+                k: v.to_dict() for k, v in self.properties.items() # pylint: disable=no-member
             }
         if not self.type:
             raise ValueError("Type is required")
@@ -60,7 +60,7 @@ class Schema(object):
         return result
 
     @classmethod
-    def from_json(self, data):
+    def from_dict(self, data):
         '''Initialize a Schema object based on the raw JSON Schema data structure.'''
         kwargs = {}
         if 'properties' in data:

--- a/singer/schema.py
+++ b/singer/schema.py
@@ -1,7 +1,6 @@
 '''Provides an object model for JSON Schema'''
 
 import json
-import attr
 
 # These are standard keys defined in the JSON Schema spec
 STANDARD_KEYS = [
@@ -19,7 +18,7 @@ STANDARD_KEYS = [
     'type'
 ]
 
-@attr.s # pylint: disable=too-many-instance-attributes
+
 class Schema(object):
     '''Object model for JSON Schema.
 
@@ -28,23 +27,28 @@ class Schema(object):
 
     '''
 
-    type = attr.ib(default=None)
-    properties = attr.ib(default={})
-    items = attr.ib(default={})
-    sqlDatatype = attr.ib(default=None)
-    selected = attr.ib(default=None)
-    inclusion = attr.ib(default=None)
-    description = attr.ib(default=None)
-    minimum = attr.ib(default=None)
-    maximum = attr.ib(default=None)
-    exclusiveMinimum = attr.ib(default=None)
-    exclusiveMaximum = attr.ib(default=None)
-    multipleOf = attr.ib(default=None)
-    maxLength = attr.ib(default=None)
-    format = attr.ib(default=None)
+    def __init__(self, type=None, properties=None, items=None, sqlDatatype=None, selected=None, inclusion=None, description=None, minimum=None, maximum=None, exclusiveMinimum=None, exclusiveMaximum=None, multipleOf=None, maxLength=None, format=None):
+
+        self.type = type
+        self.properties = properties
+        self.items = items
+        self.sqlDatatype = sqlDatatype
+        self.selected = selected
+        self.inclusion = inclusion
+        self.description = description
+        self.minimum = minimum
+        self.maximum = maximum
+        self.exclusiveMinimum = exclusiveMinimum
+        self.exclusiveMaximum = exclusiveMaximum
+        self.multipleOf = multipleOf
+        self.maxLength = maxLength
+        self.format = format
 
     def __str__(self):
         return json.dumps(self.to_dict())
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
 
     def to_dict(self):
         '''Return the raw JSON Schema as a (possibly nested) dict.'''

--- a/singer/schema.py
+++ b/singer/schema.py
@@ -19,7 +19,7 @@ STANDARD_KEYS = [
 ]
 
 
-class Schema(object):
+class Schema(object): # pylint: disable=too-many-instance-attributes
     '''Object model for JSON Schema.
 
     Tap and Target authors may find this to be more convenient than
@@ -27,7 +27,10 @@ class Schema(object):
 
     '''
 
-    def __init__(self, type=None, properties=None, items=None, sqlDatatype=None, selected=None, inclusion=None, description=None, minimum=None, maximum=None, exclusiveMinimum=None, exclusiveMaximum=None, multipleOf=None, maxLength=None, format=None):
+    def __init__(self, type=None, format=None, properties=None, items=None, # pylint: disable=redefined-builtin
+                 sqlDatatype=None, selected=None, inclusion=None, description=None,
+                 minimum=None, maximum=None, exclusiveMinimum=None,
+                 exclusiveMaximum=None, multipleOf=None, maxLength=None):
 
         self.type = type
         self.properties = properties

--- a/singer/schema.py
+++ b/singer/schema.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-builtin, too-many-arguments, invalid-name
 '''Provides an object model for JSON Schema'''
 
 import json
@@ -19,7 +20,7 @@ STANDARD_KEYS = [
 ]
 
 
-class Schema(object): # pylint: disable=too-many-instance-attributes
+class Schema(object):  # pylint: disable=too-many-instance-attributes
     '''Object model for JSON Schema.
 
     Tap and Target authors may find this to be more convenient than
@@ -27,24 +28,25 @@ class Schema(object): # pylint: disable=too-many-instance-attributes
 
     '''
 
-    def __init__(self, type=None, format=None, properties=None, items=None, # pylint: disable=redefined-builtin
-                 sqlDatatype=None, selected=None, inclusion=None, description=None,
-                 minimum=None, maximum=None, exclusiveMinimum=None,
+    def __init__(self, type=None, format=None, properties=None,
+                 items=None, sqlDatatype=None, selected=None,
+                 inclusion=None, description=None, minimum=None,
+                 maximum=None, exclusiveMinimum=None,
                  exclusiveMaximum=None, multipleOf=None, maxLength=None):
 
         self.type = type
         self.properties = properties
         self.items = items
-        self.sqlDatatype = sqlDatatype # pylint: disable=invalid-name
+        self.sqlDatatype = sqlDatatype
         self.selected = selected
         self.inclusion = inclusion
         self.description = description
         self.minimum = minimum
         self.maximum = maximum
-        self.exclusiveMinimum = exclusiveMinimum # pylint: disable=invalid-name
-        self.exclusiveMaximum = exclusiveMaximum # pylint: disable=invalid-name
-        self.multipleOf = multipleOf # pylint: disable=invalid-name
-        self.maxLength = maxLength # pylint: disable=invalid-name
+        self.exclusiveMinimum = exclusiveMinimum
+        self.exclusiveMaximum = exclusiveMaximum
+        self.multipleOf = multipleOf
+        self.maxLength = maxLength
         self.format = format
 
     def __str__(self):
@@ -58,10 +60,12 @@ class Schema(object): # pylint: disable=too-many-instance-attributes
         result = {}
         if self.properties:
             result['properties'] = {
-                k: v.to_dict() for k, v in self.properties.items() # pylint: disable=no-member
+                k: v.to_dict()
+                for k, v
+                in self.properties.items()  # pylint: disable=no-member
             }
         if self.items:
-            result['items'] = self.items.to_dict() # pylint: disable=no-member
+            result['items'] = self.items.to_dict()  # pylint: disable=no-member
         for key in STANDARD_KEYS:
             if self.__dict__[key] is not None:
                 result[key] = self.__dict__[key]
@@ -70,7 +74,7 @@ class Schema(object): # pylint: disable=too-many-instance-attributes
 
     @classmethod
     def from_dict(cls, data):
-        '''Initialize a Schema object based on the raw JSON Schema data structure.'''
+        '''Initialize a Schema object based on the JSON Schema structure.'''
         kwargs = {}
         properties = data.get('properties')
         items = data.get('items')

--- a/singer/schema.py
+++ b/singer/schema.py
@@ -1,0 +1,74 @@
+import json
+
+import attr
+
+STANDARD_KEYS = [
+    'sqlDatatype',
+    'selected',
+    'inclusion',
+    'description',
+    'minimum',
+    'maximum',
+    'exclusiveMinimum',
+    'exclusiveMaximum',
+    'multipleOf',
+    'maxLength',
+    'format',
+    'type'
+]
+
+@attr.s # pylint: disable=too-many-instance-attributes
+class Schema(object):
+    '''Object model for JSON Schema.
+
+    Tap and Target authors may find this to be more convenient than
+    working directly with JSON Schema data structures.
+
+    '''
+
+    type = attr.ib(default=None)
+    properties = attr.ib(default={})
+    sqlDatatype = attr.ib(default=None)
+    selected = attr.ib(default=None)
+    inclusion = attr.ib(default=None)
+    description = attr.ib(default=None)
+    minimum = attr.ib(default=None)
+    maximum = attr.ib(default=None)
+    exclusiveMinimum = attr.ib(default=None)
+    exclusiveMaximum = attr.ib(default=None)
+    multipleOf = attr.ib(default=None)
+    maxLength = attr.ib(default=None)
+    format = attr.ib(default=None)
+
+    def __str__(self):
+        return json.dumps(self.to_json())
+
+    def to_json(self):
+        '''Return the raw JSON Schema as a (possibly nested) dict.'''
+        result = {}
+        if self.properties:
+            result['properties'] = {
+                k: v.to_json() for k, v in self.properties.items() # pylint: disable=no-member
+            }
+        if not self.type:
+            raise ValueError("Type is required")
+
+        for key in STANDARD_KEYS:
+            if self.__dict__[key] is not None:
+                result[key] = self.__dict__[key]
+
+        return result
+
+    @classmethod
+    def from_json(self, data):
+        '''Initialize a Schema object based on the raw JSON Schema data structure.'''
+        kwargs = {}
+        if 'properties' in data:
+            kwargs['properties'] = {
+                k: load_schema(v) for k, v in data['properties'].items()
+            }
+        for key in STANDARD_KEYS:
+            if key in data:
+                kwargs[key] = data[key]
+        return Schema(**kwargs)
+

--- a/singer/schema.py
+++ b/singer/schema.py
@@ -35,16 +35,16 @@ class Schema(object): # pylint: disable=too-many-instance-attributes
         self.type = type
         self.properties = properties
         self.items = items
-        self.sqlDatatype = sqlDatatype
+        self.sqlDatatype = sqlDatatype # pylint: disable=invalid-name
         self.selected = selected
         self.inclusion = inclusion
         self.description = description
         self.minimum = minimum
         self.maximum = maximum
-        self.exclusiveMinimum = exclusiveMinimum
-        self.exclusiveMaximum = exclusiveMaximum
-        self.multipleOf = multipleOf
-        self.maxLength = maxLength
+        self.exclusiveMinimum = exclusiveMinimum # pylint: disable=invalid-name
+        self.exclusiveMaximum = exclusiveMaximum # pylint: disable=invalid-name
+        self.multipleOf = multipleOf # pylint: disable=invalid-name
+        self.maxLength = maxLength # pylint: disable=invalid-name
         self.format = format
 
     def __str__(self):

--- a/singer/schema.py
+++ b/singer/schema.py
@@ -28,6 +28,7 @@ class Schema(object):
 
     type = attr.ib(default=None)
     properties = attr.ib(default={})
+    items = attr.ib(default={})
     sqlDatatype = attr.ib(default=None)
     selected = attr.ib(default=None)
     inclusion = attr.ib(default=None)
@@ -50,6 +51,8 @@ class Schema(object):
             result['properties'] = {
                 k: v.to_dict() for k, v in self.properties.items() # pylint: disable=no-member
             }
+        if self.items:
+            result['items'] = self.items.to_dict()
         for key in STANDARD_KEYS:
             if self.__dict__[key] is not None:
                 result[key] = self.__dict__[key]
@@ -60,10 +63,15 @@ class Schema(object):
     def from_dict(self, data):
         '''Initialize a Schema object based on the raw JSON Schema data structure.'''
         kwargs = {}
-        if 'properties' in data:
+        properties = data.get('properties')
+        items = data.get('items')
+        
+        if properties:
             kwargs['properties'] = {
-                k: Schema.from_dict(v) for k, v in data['properties'].items()
+                k: Schema.from_dict(v) for k, v in properties.items()
             }
+        if items:
+            kwargs['items'] = Schema.from_dict(items)
         for key in STANDARD_KEYS:
             if key in data:
                 kwargs[key] = data[key]

--- a/singer/schema.py
+++ b/singer/schema.py
@@ -1,7 +1,7 @@
 import json
-
 import attr
 
+# These are standard keys defined in the JSON Schema spec
 STANDARD_KEYS = [
     'sqlDatatype',
     'selected',
@@ -50,9 +50,6 @@ class Schema(object):
             result['properties'] = {
                 k: v.to_dict() for k, v in self.properties.items() # pylint: disable=no-member
             }
-        if not self.type:
-            raise ValueError("Type is required")
-
         for key in STANDARD_KEYS:
             if self.__dict__[key] is not None:
                 result[key] = self.__dict__[key]
@@ -65,7 +62,7 @@ class Schema(object):
         kwargs = {}
         if 'properties' in data:
             kwargs['properties'] = {
-                k: load_schema(v) for k, v in data['properties'].items()
+                k: Schema.from_dict(v) for k, v in data['properties'].items()
             }
         for key in STANDARD_KEYS:
             if key in data:

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -72,6 +72,7 @@ def parse_args(required_config_keys):
     -c,--config     Config file
     -s,--state      State file
     -d,--discover   Run in discover mode
+    -p,--properties Properties file: DEPRECATED, please use --catalog instead
     -a,--catalog    Catalog file
 
     Returns the parsed args object from argparse. For each argument that
@@ -90,6 +91,10 @@ def parse_args(required_config_keys):
         help='State file')
 
     parser.add_argument(
+        '-p', '--properties',
+        help='Property selections: DEPRECATED, Please use --catalog instead')
+
+    parser.add_argument(
         '-a', '--catalog',
         help='Catalog file')
 
@@ -105,6 +110,8 @@ def parse_args(required_config_keys):
         args.state = load_json(args.state)
     else:
         args.state = {}
+    if args.properties:
+        args.properties = load_json(args.properties)
     if args.catalog:
         args.catalog = Catalog.load(args.catalog)
 

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -5,6 +5,8 @@ import functools
 import json
 import time
 
+from singer.catalog import Catalog
+
 DATETIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
 
 

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -73,7 +73,7 @@ def parse_args(required_config_keys):
     -s,--state      State file
     -d,--discover   Run in discover mode
     -p,--properties Properties file: DEPRECATED, please use --catalog instead
-    -a,--catalog    Catalog file
+    --catalog       Catalog file
 
     Returns the parsed args object from argparse. For each argument that
     point to JSON files (config, state, properties), we will automatically
@@ -95,7 +95,7 @@ def parse_args(required_config_keys):
         help='Property selections: DEPRECATED, Please use --catalog instead')
 
     parser.add_argument(
-        '-a', '--catalog',
+        '--catalog',
         help='Catalog file')
 
     parser.add_argument(

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -70,7 +70,7 @@ def parse_args(required_config_keys):
     -c,--config     Config file
     -s,--state      State file
     -d,--discover   Run in discover mode
-    -p,--properties Properties file
+    -a,--catalog    Catalog file
 
     Returns the parsed args object from argparse. For each argument that
     point to JSON files (config, state, properties), we will automatically
@@ -88,8 +88,8 @@ def parse_args(required_config_keys):
         help='State file')
 
     parser.add_argument(
-        '-p', '--properties',
-        help='Property selections')
+        '-a', '--catalog',
+        help='Catalog file')
 
     parser.add_argument(
         '-d', '--discover',
@@ -103,8 +103,8 @@ def parse_args(required_config_keys):
         args.state = load_json(args.state)
     else:
         args.state = {}
-    if args.properties:
-        args.properties = load_json(args.properties)
+    if args.catalog:
+        args.catalog = Catalog.load(args.catalog)
 
     check_config(args.config, required_config_keys)
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,71 @@
+import unittest
+
+from singer.schema import Schema
+from singer.catalog import Catalog, CatalogEntry
+
+class TestCatalog(unittest.TestCase):
+
+    dict_form = {
+        'streams': [
+            {
+                'stream': 'users',
+                'tap_stream_id': 'prod_users',
+                'database_name': 'prod',
+                'table_name': 'users',
+                'schema': {
+                    'type': 'object',
+                    'selected': True,
+                    'properties': {
+                        'id': {'type': 'integer', 'selected': True},
+                        'name': {'type': 'string', 'selected': True}
+                    }
+                },
+            },
+            {
+                'stream': 'orders',
+                'tap_stream_id': 'prod_orders',
+                'database_name': 'prod',
+                'table_name': 'orders',
+                'schema': {
+                    'type': 'object',
+                    'selected': True,
+                    'properties': {
+                        'id': {'type': 'integer', 'selected': True},
+                        'amount': {'type': 'number', 'selected': True}
+                        }
+                    }
+                }
+            ]
+        }
+
+    obj_form = Catalog(streams=[
+        CatalogEntry(
+            stream='users',
+            tap_stream_id='prod_users',
+            database='prod',
+            table='users',
+            schema=Schema(
+                type='object',
+                selected=True,
+                properties={
+                    'id': Schema(type='integer', selected=True),
+                    'name': Schema(type='string', selected=True)})),
+        CatalogEntry(
+            stream='orders',
+            tap_stream_id='prod_orders',
+            database='prod',
+            table='orders',
+            schema=Schema(
+                type='object',
+                selected=True,
+                properties={
+                    'id': Schema(type='integer', selected=True),
+                    'amount': Schema(type='number', selected=True)}))])
+
+    def test_from_dict(self):
+        self.assertEqual(self.obj_form, Catalog.from_dict(self.dict_form))
+
+    def test_to_dict(self):
+        self.assertEqual(self.dict_form, self.obj_form.to_dict())
+        
+            

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,28 +4,34 @@ from singer.schema import Schema
 
 class TestSchema(unittest.TestCase):
 
-    def test_constructor(self):
-        schema = Schema(
-            type='object',
-            properties={
-                'id': Schema(type='string', maxLength=32),
-                'name': Schema(type='string'),
-                'birth_date': Schema(type='string', format='date-time')})
-        self.assertEquals(
-            {'type': 'object',
-             'properties': {
-                 'id': {
-                     'type': 'string',
-                     'maxLength': 32
-                 },
-                 'name': {
-                     'type': 'string'
-                 },
-                 'birth_date': {
-                     'type': 'string',
-                     'format': 'date-time'
-                 }
-             }
+    dict_form = {
+        'type': 'object',
+        'properties': {
+            'id': {
+                'type': 'string',
+                'maxLength': 32
             },
-            schema.to_dict())              
+            'name': {
+                'type': 'string'
+            },
+            'birth_date': {
+                'type': 'string',
+                'format': 'date-time'
+            }
+        }
+    }
+
+    obj_form = Schema(
+        type='object',
+        properties={
+            'id': Schema(type='string', maxLength=32),
+            'name': Schema(type='string'),
+            'birth_date': Schema(type='string', format='date-time')})
+
+    def test_to_dict(self):
+        self.assertEquals(self.dict_form, self.obj_form.to_dict())
+
+    def test_from_dict(self):
+        self.assertEquals(self.obj_form, Schema.from_dict(self.dict_form))
                 
+    

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,31 @@
+import unittest
+
+from singer.schema import Schema
+
+class TestSchema(unittest.TestCase):
+
+    def test_constructor(self):
+        schema = Schema(
+            type='object',
+            properties={
+                'id': Schema(type='string', maxLength=32),
+                'name': Schema(type='string'),
+                'birth_date': Schema(type='string', format='date-time')})
+        self.assertEquals(
+            {'type': 'object',
+             'properties': {
+                 'id': {
+                     'type': 'string',
+                     'maxLength': 32
+                 },
+                 'name': {
+                     'type': 'string'
+                 },
+                 'birth_date': {
+                     'type': 'string',
+                     'format': 'date-time'
+                 }
+             }
+            },
+            schema.to_dict())              
+                

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,34 +4,63 @@ from singer.schema import Schema
 
 class TestSchema(unittest.TestCase):
 
-    dict_form = {
+    # Raw data structures for several schema types
+    string_dict = {
+        'type': 'string',
+        'maxLength': 32
+    }
+
+    integer_dict = {
+        'type': 'integer',
+        'maximum': 1000000
+    }
+
+    array_dict = {
+        'type': 'array',
+        'items': integer_dict
+    }
+
+    object_dict = {
         'type': 'object',
         'properties': {
-            'id': {
-                'type': 'string',
-                'maxLength': 32
-            },
-            'name': {
-                'type': 'string'
-            },
-            'birth_date': {
-                'type': 'string',
-                'format': 'date-time'
-            }
+            'a_string': string_dict,
+            'an_array': array_dict
         }
     }
 
-    obj_form = Schema(
-        type='object',
-        properties={
-            'id': Schema(type='string', maxLength=32),
-            'name': Schema(type='string'),
-            'birth_date': Schema(type='string', format='date-time')})
+    # Schema object forms of the same schemas as above
+    string_obj = Schema(type='string', maxLength=32)
 
-    def test_to_dict(self):
-        self.assertEquals(self.dict_form, self.obj_form.to_dict())
+    integer_obj = Schema(type='integer', maximum=1000000)
 
-    def test_from_dict(self):
-        self.assertEquals(self.obj_form, Schema.from_dict(self.dict_form))
+    array_obj = Schema(type='array', items=integer_obj)
+
+    object_obj = Schema(type='object',
+                        properties={'a_string': string_obj,
+                                    'an_array': array_obj})
+
+    def test_string_to_dict(self):
+        self.assertEquals(self.string_dict, self.string_obj.to_dict())
+
+    def test_integer_to_dict(self):
+        self.assertEquals(self.integer_dict, self.integer_obj.to_dict())
+
+    def test_array_to_dict(self):
+        self.assertEquals(self.array_dict, self.array_obj.to_dict())
+
+    def test_object_to_dict(self):
+        self.assertEquals(self.object_dict, self.object_obj.to_dict())        
+
+    def test_string_from_dict(self):
+        self.assertEquals(self.string_obj, Schema.from_dict(self.string_dict))
+
+    def test_integer_from_dict(self):
+        self.assertEquals(self.integer_obj, Schema.from_dict(self.integer_dict))
+
+    def test_array_from_dict(self):        
+        self.assertEquals(self.array_obj, Schema.from_dict(self.array_dict))
+
+    def test_object_from_dict(self):        
+        self.assertEquals(self.object_obj, Schema.from_dict(self.object_dict))        
                 
     


### PR DESCRIPTION
Add object models for Schema and Catalog. See https://github.com/singer-io/tap-mysql/pull/15 for example usage.

* Add singer.schema. This contains a Schema class that represents a JSON Schema. If you're building a schema from scratch, you can use the constructor. If you're loading it from a file, you can use `Schema.load()`.
* Add singer.catalog. This contains a Catalog class. Usage is similar to `singer.schema.Schema`.
* Add a `--catalog` option to the command-line options defined in `singer.utils`. `singer.utils.parse_args` will now load a Catalog object automatically if the `--catalog` option is defined. I left the `--properties` option there but marked it as deprecated.