### PR TITLE
Add version

### DIFF
--- a/singer/__init__.py
+++ b/singer/__init__.py
@@ -10,7 +10,7 @@ from singer import transform
 class Message(object):
     '''Base class for messages.'''
 
-    def asdict(self):
+    def asdict(self):  # pylint: disable=no-self-use
         raise Exception('Not implemented')
 
     def __eq__(self, other):

--- a/singer/__init__.py
+++ b/singer/__init__.py
@@ -96,11 +96,14 @@ class StateMessage(Message):
         }
 
 class ActivateVersionMessage(Message):
-    '''ACTIVATE_VERSION message.
+    '''ACTIVATE_VERSION message (EXPERIMENTAL).
 
     >>> msg = singer.ActivateVersionMessage(
     >>>     stream='users',
     >>>     version=2)
+
+    Note that this feature is experimental and should not be relied on for
+    production use.
 
     '''
     def __init__(self, stream, version):

--- a/singer/__init__.py
+++ b/singer/__init__.py
@@ -10,6 +10,9 @@ from singer import transform
 class Message(object):
     '''Base class for messages.'''
 
+    def asdict(self):
+        raise Exception('Not implemented')
+
     def __eq__(self, other):
         return isinstance(other, Message) and self.asdict() == other.asdict()
 

--- a/tests/test_singer.py
+++ b/tests/test_singer.py
@@ -10,6 +10,13 @@ class TestSinger(unittest.TestCase):
             message,
             singer.RecordMessage(record={'name': 'foo'}, stream='users'))
 
+    def test_parse_message_record_with_version_good(self):
+        message = singer.parse_message(
+            '{"type": "RECORD", "record": {"name": "foo"}, "stream": "users", "version": 2}')
+        self.assertEqual(
+            message,
+            singer.RecordMessage(record={'name': 'foo'}, stream='users', version=2))        
+
     def test_parse_message_record_missing_record(self):
         with self.assertRaises(Exception):
             singer.parse_message('{"type": "RECORD", "stream": "users"}')
@@ -68,11 +75,11 @@ class TestSinger(unittest.TestCase):
         state_message = singer.StateMessage(value={'seq': 1})
 
         self.assertEqual(record_message,
-                         singer.parse_message(record_message.tojson()))
+                         singer.parse_message(singer.format_message(record_message)))
         self.assertEqual(schema_message,
-                         singer.parse_message(schema_message.tojson()))
+                         singer.parse_message(singer.format_message(schema_message)))
         self.assertEqual(state_message,
-                         singer.parse_message(state_message.tojson()))
+                         singer.parse_message(singer.format_message(state_message)))
 
     ## These three tests just confirm that writing doesn't throw
 

--- a/tests/test_singer.py
+++ b/tests/test_singer.py
@@ -15,7 +15,7 @@ class TestSinger(unittest.TestCase):
             '{"type": "RECORD", "record": {"name": "foo"}, "stream": "users", "version": 2}')
         self.assertEqual(
             message,
-            singer.RecordMessage(record={'name': 'foo'}, stream='users', version=2))        
+            singer.RecordMessage(record={'name': 'foo'}, stream='users', version=2))
 
     def test_parse_message_record_missing_record(self):
         with self.assertRaises(Exception):
@@ -73,7 +73,7 @@ class TestSinger(unittest.TestCase):
                         'name': {'type': 'string'}}})
 
         state_message = singer.StateMessage(value={'seq': 1})
-
+        
         self.assertEqual(record_message,
                          singer.parse_message(singer.format_message(record_message)))
         self.assertEqual(schema_message,


### PR DESCRIPTION
We want to support for an experimental feature for versioning source data.

1. Add an optional `version` field to `RECORD` messages
2. Add an `ACTIVATE_VERSION` message.

The `version` field is the first field we have that's optional. This adds some complexity to the library, because so far all of the fields listed in the "attr list" are required, and many parts of the library depend on that being the case. I just went and changed the RecordMessage, SchemaMessage, and StateMessage classes to be plain old classes and not use or "attr list" thing. I decided to do that instead of use the `attrs` library that we use in some Taps because I'd like to keep the list of dependencies light in order to avoid potential dependency conflicts.

I added a unit test for the new stuff and verified that the existing tests pass.