### PR TITLE
Add get_stream

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,4 @@ dependencies:
 
 test:
   post:
-    - pylint singer -d missing-docstring,broad-except,bare-except,too-many-return-statements,too-many-branches,too-many-arguments,no-else-return,too-few-public-methods
+    - pylint singer -d missing-docstring,broad-except,bare-except,too-many-return-statements,too-many-branches,too-many-arguments,no-else-return,too-few-public-methods,fixme

--- a/singer/catalog.py
+++ b/singer/catalog.py
@@ -74,6 +74,11 @@ class Catalog(object):
 
     @classmethod
     def from_dict(cls, data):
+        # TODO: We may want to store streams as a dict where the key is a
+        # tap_stream_id and the value is a CatalogEntry. This will allow
+        # faster lookup based on tap_stream_id. This would be a breaking
+        # change, since callers typically access the streams property
+        # directly.
         streams = []
         for stream in data['streams']:
             entry = CatalogEntry()
@@ -93,3 +98,9 @@ class Catalog(object):
 
     def dump(self):
         json.dump(self.to_dict(), sys.stdout, indent=2)
+
+    def get_stream(self, tap_stream_id):
+        for stream in self.streams:
+            if stream.tap_stream_id == tap_stream_id:
+                return stream
+        return None

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -3,7 +3,7 @@ import unittest
 from singer.schema import Schema
 from singer.catalog import Catalog, CatalogEntry
 
-class TestCatalog(unittest.TestCase):
+class TestToDictAndFromDict(unittest.TestCase):
 
     dict_form = {
         'streams': [
@@ -68,4 +68,12 @@ class TestCatalog(unittest.TestCase):
     def test_to_dict(self):
         self.assertEqual(self.dict_form, self.obj_form.to_dict())
         
-            
+
+class TestGetStream(unittest.TestCase):
+    def test(self):
+        catalog = Catalog(
+            [CatalogEntry(tap_stream_id='a'),
+             CatalogEntry(tap_stream_id='b'),
+             CatalogEntry(tap_stream_id='c')])
+        entry = catalog.get_stream('b')
+        self.assertEquals('b', entry.tap_stream_id)


### PR DESCRIPTION
Add `Catalog.get_stream(tap_stream_id)` for finding a stream by tap_stream_id.