### PR TITLE
Accept key_properties as tuple

### DIFF
--- a/singer/__init__.py
+++ b/singer/__init__.py
@@ -182,7 +182,7 @@ def write_schema(stream_name, schema, key_properties,stream_alias=None):
     """
     if isinstance(key_properties, (str, bytes)):
         key_properties = [key_properties]
-    if not isinstance(key_properties, list):
+    if not isinstance(key_properties, (list, tuple)):
         raise Exception("key_properties must be a string or list of strings")
     write_message(
         SchemaMessage(

--- a/tests/test_singer.py
+++ b/tests/test_singer.py
@@ -81,7 +81,7 @@ class TestSinger(unittest.TestCase):
         self.assertEqual(state_message,
                          singer.parse_message(singer.format_message(state_message)))
 
-    ## These three tests just confirm that writing doesn't throw
+    ## These tests just confirm that writing doesn't throw
 
     def test_write_record(self):
         singer.write_record("users", {"name": "mike"})
@@ -91,6 +91,12 @@ class TestSinger(unittest.TestCase):
                 'properties': {
                     'name': {'type': 'string'}}}
         singer.write_schema("users", schema, ["name"])
+
+    def test_write_schema_key_properties_tuple(self):
+        schema={'type': 'object',
+                'properties': {
+                    'name': {'type': 'string'}}}
+        singer.write_schema("users", schema, ("name",))
 
     def test_write_state(self):
         singer.write_state({"foo": 1})


### PR DESCRIPTION
This check is a little bothersome. 

Out of habit, will use tuples over lists if i'm working with something immutable.

Hit `Exception("key_properties must be a string or list of strings")` while making first python tap, just out of the habit of using tuples for definition like this.

```python
singer.write_schema('looker_data', schema, key_properties=('users.joined_week', 'users.channel'))
```
(Hint at the WIP tap :bowtie:)

Whether key_properties should accept strings at all, or if this is the best way of checking, are questions for another day. Just wanted the smallest diff. All tests pass, and didn't see any other checks this could mess with at a glance.