### PR TITLE
Adds functionality for resolving JSON schema refs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(name="singer-python",
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       url="http://singer.io",
       install_requires=[
+          'jsonschema==2.6.0',
           'pendulum==1.2.0',
           'simplejson==3.11.1',
           'python-dateutil==2.6.0',

--- a/singer/__init__.py
+++ b/singer/__init__.py
@@ -41,6 +41,7 @@ from singer.transform import (
     Transformer,
     transform,
     _transform_datetime,
+    resolve_schema_references
 )
 
 from singer.catalog import Catalog

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -260,7 +260,7 @@ def _transform_datetime(value, integer_datetime_fmt=NO_INTEGER_DATETIME_PARSING)
     transformer = Transformer(integer_datetime_fmt)
     return transformer._transform_datetime(value)
 
-def resolve_schema_references(schema, refs={}):
+def resolve_schema_references(schema, refs={}): #pylint: disable=dangerous-default-value
     '''Resolves and replaces json-schema $refs with the appropriate dict.
 
     Recursively walks the given schema dict, converting every instance
@@ -284,8 +284,8 @@ def _resolve_schema_references(schema, resolver):
         return _resolve_schema_references(resolver.resolve(schema[SchemaKey.ref])[1], resolver)
 
     if SchemaKey.properties in schema:
-        for k, v in schema[SchemaKey.properties].items():
-            schema[SchemaKey.properties][k] = _resolve_schema_references(v, resolver)
+        for k, val in schema[SchemaKey.properties].items():
+            schema[SchemaKey.properties][k] = _resolve_schema_references(val, resolver)
 
     if SchemaKey.items in schema:
         schema[SchemaKey.items] = _resolve_schema_references(schema[SchemaKey.items], resolver)

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -281,7 +281,10 @@ def resolve_schema_references(schema, refs={}): #pylint: disable=dangerous-defau
 
 def _resolve_schema_references(schema, resolver):
     if SchemaKey.ref in schema:
-        return _resolve_schema_references(resolver.resolve(schema[SchemaKey.ref])[1], resolver)
+        reference_path = schema.pop(SchemaKey.ref, None)
+        resolved = resolver.resolve(reference_path)[1]
+        schema.update(resolved)
+        return _resolve_schema_references(schema, resolver)
 
     if SchemaKey.properties in schema:
         for k, val in schema[SchemaKey.properties].items():

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -3,6 +3,7 @@ import pendulum
 from singer.logger import get_logger
 from singer.utils import strftime
 
+from jsonschema import RefResolver
 
 LOGGER = get_logger()
 
@@ -44,6 +45,10 @@ class SchemaMismatch(Exception):
 
         super(SchemaMismatch, self).__init__(msg)
 
+class SchemaKey:
+    ref = "$ref"
+    items = "items"
+    properties = "properties"
 
 class Error:
     def __init__(self, path, data, schema=None):
@@ -254,3 +259,35 @@ def transform(data, schema, integer_datetime_fmt=NO_INTEGER_DATETIME_PARSING, pr
 def _transform_datetime(value, integer_datetime_fmt=NO_INTEGER_DATETIME_PARSING):
     transformer = Transformer(integer_datetime_fmt)
     return transformer._transform_datetime(value)
+
+def resolve_schema_references(schema, refs={}):
+    '''Resolves and replaces json-schema $refs with the appropriate dict
+
+    Recursively walks the given schema dict, converting every instance
+    of $ref in a 'properties' structure with a resolved dict.
+
+    This modifies the input schema and also returns it.
+
+    Arguments:
+        schema:
+            the schema dict
+        resolver:
+            a RefResolver with a complete `store` of referenced schemata
+
+    Returns:
+        schema
+    '''
+    return _resolve_schema_references(schema, RefResolver("", schema, store=refs))
+
+def _resolve_schema_references(schema, resolver):
+    if SchemaKey.ref in schema:
+        return _resolve_schema_references(resolver.resolve(schema[SchemaKey.ref])[1], resolver)
+
+    if SchemaKey.properties in schema:
+        for k, v in schema[SchemaKey.properties].items():
+            schema[SchemaKey.properties][k] = _resolve_schema_references(v, resolver)
+
+    if SchemaKey.items in schema:
+        schema[SchemaKey.items] = _resolve_schema_references(schema[SchemaKey.items], resolver)
+
+    return schema

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -261,7 +261,7 @@ def _transform_datetime(value, integer_datetime_fmt=NO_INTEGER_DATETIME_PARSING)
     return transformer._transform_datetime(value)
 
 def resolve_schema_references(schema, refs={}):
-    '''Resolves and replaces json-schema $refs with the appropriate dict
+    '''Resolves and replaces json-schema $refs with the appropriate dict.
 
     Recursively walks the given schema dict, converting every instance
     of $ref in a 'properties' structure with a resolved dict.
@@ -271,8 +271,8 @@ def resolve_schema_references(schema, refs={}):
     Arguments:
         schema:
             the schema dict
-        resolver:
-            a RefResolver with a complete `store` of referenced schemata
+        refs:
+            a dict of <string, dict> which forms a store of referenced schemata
 
     Returns:
         schema

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -275,3 +275,12 @@ class TestResolveSchemaReferences(unittest.TestCase):
                  "second_reference.json": {"type": "string"}}
         result = resolve_schema_references(schema, refs)
         self.assertEqual(result['properties']['name']['type'], "string")
+
+    def test_refs_resolve_preserves_existing_fields(self):
+        schema =  {"type": "object",
+                   "properties": { "name": {"$ref": "references.json#/definitions/string_type",
+                                            "still_here": "yep"}}}
+        refs =  {"references.json": {"definitions": { "string_type": {"type": "string"}}}}
+        result = resolve_schema_references(schema, refs)
+        self.assertEqual(result['properties']['name']['type'], "string")
+        self.assertEqual(result['properties']['name']['still_here'], "yep")

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -258,8 +258,6 @@ class TestResolveSchemaReferences(unittest.TestCase):
         self.assertEqual(result['properties']['dogs']['items']['properties']['breed'], {"type": "string"})
 
     def test_refs_resolve_nested(self):
-        # Nested schemas[0]['properties']['foo']['properties']['bar']['type'] == "string" its recursive
-        # properties -> thing -> properties -> $ref
         schema = {"type": "object",
                    "properties": {
                        "thing": {


### PR DESCRIPTION
Adds a recursive helper function for replacing JSON schema `$ref` data with the appropriate dict. 

Useful for JSON schemas that have a large amount of duplicated data and can benefit from a shared schema.