### PR TITLE
update resolving function to resolve refs for patternProperties

### DIFF
--- a/singer/transform.py
+++ b/singer/transform.py
@@ -49,6 +49,7 @@ class SchemaKey:
     ref = "$ref"
     items = "items"
     properties = "properties"
+    pattern_properties = "patternProperties"
 
 class Error:
     def __init__(self, path, data, schema=None):
@@ -291,6 +292,10 @@ def _resolve_schema_references(schema, resolver):
     if SchemaKey.properties in schema:
         for k, val in schema[SchemaKey.properties].items():
             schema[SchemaKey.properties][k] = _resolve_schema_references(val, resolver)
+
+    if SchemaKey.pattern_properties in schema:
+        for k, val in schema[SchemaKey.pattern_properties].items():
+            schema[SchemaKey.pattern_properties][k] = _resolve_schema_references(val, resolver)
 
     if SchemaKey.items in schema:
         schema[SchemaKey.items] = _resolve_schema_references(schema[SchemaKey.items], resolver)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -233,13 +233,19 @@ class TestResolveSchemaReferences(unittest.TestCase):
         result = resolve_schema_references(schema)
         self.assertEqual(result['properties']['name']['type'], "string")
 
-
     def test_external_refs_resolve(self):
         schema =  {"type": "object",
                    "properties": { "name": {"$ref": "references.json#/definitions/string_type"}}}
         refs =  {"references.json": {"definitions": { "string_type": {"type": "string"}}}}
         result = resolve_schema_references(schema, refs)
         self.assertEqual(result['properties']['name']['type'], "string")
+
+    def test_refs_resolve_pattern_properties(self):
+        schema =  {"type": "object",
+                   "definitions": { "string_type": {"type": "string"}},
+                   "patternProperties": {".+": {"$ref": "#/definitions/string_type"}}}
+        result = resolve_schema_references(schema)
+        self.assertEqual(result["patternProperties"][".+"]["type"], "string")
 
     def test_refs_resolve_items(self):
         schema =  {"type": "object",


### PR DESCRIPTION
The Jira JSON schemas makes heavy use of "patternProperties." This JSON schema keyword is a regex that allows any properties matching the pattern.

This change modifies the code that resolves references so it handles these cases. 