### PR TITLE
A missing 'type' key indicates any type so don't transform

### DIFF
--- a/singer/transform.py
+++ b/singer/transform.py
@@ -100,8 +100,8 @@ class Transformer:
             return self._transform_anyof(data, schema, path)
 
         if "type" not in schema:
-            # pylint: disable=line-too-long
-            raise Exception("Malformed schema. Missing 'type'. schema={} path={}".format(schema, path))
+            # indicates no typing information so don't bother transforming it
+            return True, data
 
         types = schema["type"]
         if not isinstance(types, list):


### PR DESCRIPTION
Modifies the recursive code to no longer raise an exception when the `"type"` key is missing from the schema. We can use a missing type to validate any JSON data.

> In addition, we also have the empty schema, that specifies all possible types of JSON documents.
-- https://cswr.github.io/JsonSchema/spec/multiple_types/

