### PR TITLE
Fix transformation when schema has multiple types

### DIFF
--- a/singer/transform.py
+++ b/singer/transform.py
@@ -132,10 +132,11 @@ class Transformer:
             return False, None
 
     def _transform_object(self, data, schema, path):
-        # only a schema of "null" can match a null value
-        # NB> This will not fail an empty dictionary, i.e. {}
-        if data is None:
-            return False, None
+        # We do not necessarily have a dict to transform here. The schema's
+        # type could contain multiple possible values. Eg:
+        #     ["null", "object", "string"]
+        if not isinstance(data, dict):
+            return False, data
 
         result = {}
         successes = []
@@ -151,6 +152,11 @@ class Transformer:
         return all(successes), result
 
     def _transform_array(self, data, schema, path):
+        # We do not necessarily have a list to transform here. The schema's
+        # type could contain multiple possible values. Eg:
+        #     ["null", "array", "integer"]
+        if not isinstance(data, list):
+            return False, data
         result = []
         successes = []
         for i, row in enumerate(data):

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -22,6 +22,27 @@ class TestTransform(unittest.TestCase):
         expected = {'addrs': [{'amount': 123}, {'amount': 456}]}
         self.assertDictEqual(expected, transform(data, schema))
 
+    def test_multi_type_object_transform(self):
+        schema =  {"type": ["null", "object", "string"],
+                   "properties": {"whatever": {"type": "date-time",
+                                               "format": "date-time"}}}
+        data = {"whatever": "2017-01-01"}
+        expected = {"whatever": "2017-01-01T00:00:00.000000Z"}
+        self.assertDictEqual(expected, transform(data, schema))
+        data = "justastring"
+        expected = "justastring"
+        self.assertEqual(expected, transform(data, schema))
+
+    def test_multi_type_array_transform(self):
+        schema =  {"type": ["null", "array", "integer"],
+                   "items": {"type": "date-time", "format": "date-time"}}
+        data = ["2017-01-01"]
+        expected = ["2017-01-01T00:00:00.000000Z"]
+        self.assertEqual(expected, transform(data, schema))
+        data = 23
+        expected = 23
+        self.assertEqual(expected, transform(data, schema))
+
     def test_null_transform(self):
         self.assertEqual('', transform('', {'type': ['null', 'string']}))
         self.assertEqual('', transform('', {'type': [ 'string', 'null']}))


### PR DESCRIPTION
I am running into an issue because I have a scenario where a given key can be either a string or an object. The transform function failed because of this - when the data was a string instead of an object, the ".items()" function fails.

