### PR TITLE
fix support for "type": ["array", "null"]

### DIFF
--- a/singer/transform.py
+++ b/singer/transform.py
@@ -151,6 +151,11 @@ class Transformer:
         return all(successes), result
 
     def _transform_array(self, data, schema, path):
+        # only a schema of "null" can match a null value
+        # NB> This will not fail an empty array, i.e. []
+        if data is None:
+            return False, None
+
         result = []
         successes = []
         for i, row in enumerate(data):

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -225,6 +225,15 @@ class TestTransform(unittest.TestCase):
         empty_data = {'addrs': {}}
         self.assertDictEqual(empty_data, transform(empty_data, schema))
 
+    def test_null_array_transform(self):
+        schema =  {"type": "object",
+                   "properties": {"addrs": {"type": ["null", "array"],
+                                            "items": {"type": ["null", "string"]}}}}
+        none_data = {'addrs': None}
+        self.assertDictEqual(none_data, transform(none_data, schema))
+        empty_data = {'addrs': []}
+        self.assertDictEqual(empty_data, transform(empty_data, schema))
+
 class TestResolveSchemaReferences(unittest.TestCase):
     def test_internal_refs_resolve(self):
         schema =  {"type": "object",


### PR DESCRIPTION
Analogous to how we support ["object", "null"]