### PR TITLE
Fix formatting of dates when they are < 1000

### DIFF
--- a/singer/utils.py
+++ b/singer/utils.py
@@ -11,7 +11,7 @@ import backoff as backoff_module
 from singer.catalog import Catalog
 
 DATETIME_PARSE = "%Y-%m-%dT%H:%M:%SZ"
-DATETIME_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
+DATETIME_FMT = "%04Y-%m-%dT%H:%M:%S.%fZ"
 
 def now():
     return datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
@@ -32,7 +32,7 @@ def strptime(dtime):
 def strftime(dtime):
     if dtime.utcoffset() != datetime.timedelta(0):
         raise Exception("datetime must be pegged at UTC tzoneinfo")
-    return dtime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    return dtime.strftime(DATETIME_FMT)
 
 def ratelimit(limit, every):
     def limitdecorator(func):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,10 @@
+import unittest
+from datetime import datetime as dt
+from datetime import timezone as tz
+import singer.utils as u
+
+
+class TestFormat(unittest.TestCase):
+    def test_small_years(self):
+        self.assertEqual(u.strftime(dt(90, 1, 1, tzinfo=tz.utc)),
+                         "0090-01-01T00:00:00.000000Z")


### PR DESCRIPTION
Currently if you have a date-time where the year is < 1000 then the `strftime` function will not pad zeros to the left of the date. This fixes that.

