### PR TITLE
Add additionalProperties support to Schema

### DIFF
--- a/singer/schema.py
+++ b/singer/schema.py
@@ -15,7 +15,8 @@ STANDARD_KEYS = [
     'multipleOf',
     'maxLength',
     'format',
-    'type'
+    'type',
+    'additionalProperties',
 ]
 
 
@@ -30,7 +31,7 @@ class Schema(object):  # pylint: disable=too-many-instance-attributes
     def __init__(self, type=None, format=None, properties=None, items=None,
                  selected=None, inclusion=None, description=None, minimum=None,
                  maximum=None, exclusiveMinimum=None, exclusiveMaximum=None,
-                 multipleOf=None, maxLength=None):
+                 multipleOf=None, maxLength=None, additionalProperties=None):
 
         self.type = type
         self.properties = properties
@@ -45,6 +46,7 @@ class Schema(object):  # pylint: disable=too-many-instance-attributes
         self.multipleOf = multipleOf
         self.maxLength = maxLength
         self.format = format
+        self.additionalProperties = additionalProperties
 
     def __str__(self):
         return json.dumps(self.to_dict())

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -27,6 +27,7 @@ class TestSchema(unittest.TestCase):
             'an_array': array_dict
         },
         'inclusion': 'whatever',
+        'additionalProperties': True,
     }
 
     # Schema object forms of the same schemas as above
@@ -39,7 +40,8 @@ class TestSchema(unittest.TestCase):
     object_obj = Schema(type='object',
                         properties={'a_string': string_obj,
                                     'an_array': array_obj},
-                        inclusion='whatever')
+                        inclusion='whatever',
+                        additionalProperties=True)
 
     def test_string_to_dict(self):
         self.assertEquals(self.string_dict, self.string_obj.to_dict())


### PR DESCRIPTION
The Schema class doesn't support the `additionalProperties` key which means this property is not printed during discovery. This is causing an issue in the linter I am working on https://github.com/b-ryan/singer-best-practices-linter

