### PR TITLE
Changing SchemaMessage so that bookmark_properties is always a list

### DIFF
--- a/singer/messages.py
+++ b/singer/messages.py
@@ -89,12 +89,13 @@ class SchemaMessage(Message):
         self.stream = stream
         self.schema = schema
         self.key_properties = key_properties
-        self.bookmark_properties = bookmark_properties
 
         if isinstance(bookmark_properties, (str, bytes)):
             bookmark_properties = [bookmark_properties]
         if bookmark_properties and not isinstance(bookmark_properties, list):
             raise Exception("bookmark_properties must be a string or list of strings")
+
+       self.bookmark_properties = bookmark_properties
 
     def asdict(self):
         result = {

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -95,7 +95,7 @@ class SchemaMessage(Message):
         if bookmark_properties and not isinstance(bookmark_properties, list):
             raise Exception("bookmark_properties must be a string or list of strings")
 
-       self.bookmark_properties = bookmark_properties
+        self.bookmark_properties = bookmark_properties
 
     def asdict(self):
         result = {


### PR DESCRIPTION
Fixed bug where the initializer for SchemaMessage was forcing the passed argument 'bookmark_properties' to be a list rather than forcing it's attribute 'self.bookmark_properties' to be a list.