### PR TITLE
Add metadata assignment to Catalog.from_dict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ ENV/
 .ropeproject
 
 .pypirc
+
+# PyCharm
+.idea/

--- a/singer/catalog.py
+++ b/singer/catalog.py
@@ -95,6 +95,7 @@ class Catalog(object):
             entry.schema = Schema.from_dict(stream.get('schema'))
             entry.is_view = stream.get('is_view')
             entry.stream_alias = stream.get('stream_alias')
+            entry.metadata = stream.get('metadata')
             streams.append(entry)
         return Catalog(streams)
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -20,6 +20,17 @@ class TestToDictAndFromDict(unittest.TestCase):
                         'name': {'type': 'string', 'selected': True}
                     }
                 },
+                'metadata': [
+                    {
+                        'metadata': {
+                            'metadata-key': 'metadata-value'
+                        },
+                        'breadcrumb': [
+                            'properties',
+                            'name',
+                        ],
+                    },
+                ],
             },
             {
                 'stream': 'orders',
@@ -49,7 +60,16 @@ class TestToDictAndFromDict(unittest.TestCase):
                 selected=True,
                 properties={
                     'id': Schema(type='integer', selected=True),
-                    'name': Schema(type='string', selected=True)})),
+                    'name': Schema(type='string', selected=True)}),
+            metadata=[{
+                'metadata': {
+                    'metadata-key': 'metadata-value'
+                },
+                'breadcrumb': [
+                    'properties',
+                    'name',
+                ],
+            }]),
         CatalogEntry(
             stream='orders',
             tap_stream_id='prod_orders',


### PR DESCRIPTION
`metadata` is a property on `CatalogEntry` but is not passed along from `Catalog` creation when using `from_dict()`.

`test_catalog` updated to test for cases where `metadata` is included and excluded.