### PR TITLE
Add stream_alias to Catalog.to_dict

### DIFF
--- a/singer/catalog.py
+++ b/singer/catalog.py
@@ -55,6 +55,8 @@ class CatalogEntry(object):
             result['stream'] = self.stream
         if self.row_count is not None:
             result['row_count'] = self.row_count
+        if self.stream_alias is not None:
+            result['stream_alias'] = self.stream_alias
         if self.metadata is not None:
             result['metadata'] = self.metadata
         return result

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -10,6 +10,7 @@ class TestToDictAndFromDict(unittest.TestCase):
             {
                 'stream': 'users',
                 'tap_stream_id': 'prod_users',
+                'stream_alias': 'users_alias',
                 'database_name': 'prod',
                 'table_name': 'users',
                 'schema': {
@@ -42,6 +43,7 @@ class TestToDictAndFromDict(unittest.TestCase):
         CatalogEntry(
             stream='users',
             tap_stream_id='prod_users',
+            stream_alias='users_alias',
             database='prod',
             table='users',
             schema=Schema(


### PR DESCRIPTION
`stream_alias` is a property on `CatalogEntry` but does not currently get dumped out in `to_dict`.

`test_catalog` updated to test for cases where stream_alias is included and excluded.