### PR TITLE
Decorator for wrapping main functions with critical log

### DIFF
--- a/singer/utils.py
+++ b/singer/utils.py
@@ -169,3 +169,18 @@ def exception_is_4xx(exception):
         return False
 
     return 400 <= exception.response.status_code < 500
+
+
+def handle_top_exception(logger):
+    """A decorator that will catch exceptions and log the exception's message
+    as a CRITICAL log."""
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapped(*args, **kwargs):
+            try:
+                return fn(*args, **kwargs)
+            except Exception as exc:
+                logger.critical(exc)
+                raise
+        return wrapped
+    return decorator

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import datetime as dt
 from datetime import timezone as tz
+import logging
 import singer.utils as u
 
 
@@ -8,3 +9,20 @@ class TestFormat(unittest.TestCase):
     def test_small_years(self):
         self.assertEqual(u.strftime(dt(90, 1, 1, tzinfo=tz.utc)),
                          "0090-01-01T00:00:00.000000Z")
+
+
+class TestHandleException(unittest.TestCase):
+    def setUp(self):
+        self.logger = logging.getLogger(__name__)
+
+    def test_successful_fn(self):
+        @u.handle_top_exception(self.logger)
+        def foo():
+            return 3
+        self.assertEqual(foo(), 3)
+
+    def test_exception_fn(self):
+        @u.handle_top_exception(self.logger)
+        def foo():
+            raise RuntimeError("foo")
+        self.assertRaises(RuntimeError, foo)


### PR DESCRIPTION
I figured this decorator could come in handy. Every tap has code like:

```python
def main_impl():
    ....

def main():
    try:
        main_impl()
    except ...
        LOGGER.critical....
```

Using this decorator would allow just doing this:

```python
@handle_top_exception(LOGGER)
def main():
    ....
```