### PR TITLE
changing strftime format string

### DIFF
--- a/singer/utils.py
+++ b/singer/utils.py
@@ -11,7 +11,7 @@ import backoff as backoff_module
 from singer.catalog import Catalog
 
 DATETIME_PARSE = "%Y-%m-%dT%H:%M:%SZ"
-DATETIME_FMT = "%04Y-%m-%dT%H:%M:%S.%fZ"
+DATETIME_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 def now():
     return datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
@@ -29,10 +29,10 @@ def strptime(dtime):
     except Exception:
         return datetime.datetime.strptime(dtime, DATETIME_PARSE)
 
-def strftime(dtime):
+def strftime(dtime, format_str=DATETIME_FMT):
     if dtime.utcoffset() != datetime.timedelta(0):
         raise Exception("datetime must be pegged at UTC tzoneinfo")
-    return dtime.strftime(DATETIME_FMT)
+    return dtime.strftime(format_str)
 
 def ratelimit(limit, every):
     def limitdecorator(func):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,5 +6,5 @@ import singer.utils as u
 
 class TestFormat(unittest.TestCase):
     def test_small_years(self):
-        self.assertEqual(u.strftime(dt(90, 1, 1, tzinfo=tz.utc)),
+        self.assertEqual(u.strftime(dt(90, 1, 1, tzinfo=tz.utc), '%04Y-%m-%dT%H:%M:%S.%fZ'),
                          "0090-01-01T00:00:00.000000Z")


### PR DESCRIPTION
In response to this issue [#59](https://github.com/singer-io/singer-python/issues/59)

Some C Libraries version of strftime() recognize a field width modifier in the format string, e.g. the ```04``` in ```%04Y-%m-%dT%H:%M:%S.%fZ``` which specifies the width of the year field.  

We added this ```04``` to our date format to ensure that dates with years < 1000 still have a 4 digit year.

However, other C Libraries do not recognize this field width modifier, but zero pad dates with years < 1000 to ensure they are 4 digits long.  

To remedy this inconsistency, the ```04``` is being removed from the date format string, and an optional argument is being added to singer.utils.strftime() so callers of that function can supply their own date format string.

