### PR TITLE
Provide get_default_args_parser

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# How to Contribute
+
+## Submitting a PR
+
+1. Please make sure that all tests pass and that the code passes linting
+   with `make`.
+
+1. Open up the PR.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.DEFAULT_GOAL := test
+
+check_prereqs:
+	bash -c '[[ -n $$VIRTUAL_ENV ]]'
+	bash -c '[[ $$(python3 --version) == *3.4.3* ]]'
+
+install: check_prereqs
+	python3 -m pip install -e '.[dev]'
+
+test: install
+	pylint singer -d missing-docstring,broad-except,bare-except,too-many-return-statements,too-many-branches,too-many-arguments,no-else-return,too-few-public-methods,fixme,protected-access
+	nosetests -v

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Next, install this library:
 source ~/.virtualenvs/singer-python/bin/activate
 git clone http://github.com/singer-io/singer-python
 cd singer-python
-python -m pip install -e .
+make install
 ```
 
 Now, from python code within the same `virtualenv`, you can use the

--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ This library depends on python3. We recommend using a `virtualenv`
 like this:
 
 ```bash
-› mkvirtualenv -p python3 singer
+python3 -m venv ~/.virtualenvs/singer-python
 ```
 
 Next, install this library:
 
 ```bash
-› workon singer
-› git clone http://github.com/singer-io/singer-python
-› cd singer-python
-› python setup.py install
+source ~/.virtualenvs/singer-python/bin/activate
+git clone http://github.com/singer-io/singer-python
+cd singer-python
+python -m pip install -e .
 ```
 
 Now, from python code within the same `virtualenv`, you can use the

--- a/bin/circle_deps
+++ b/bin/circle_deps
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+mkdir -p ~/.virtualenvs/singer-python
+pyenv global 3.4.3
+python3 -m venv ~/.virtualenvs/singer-python
+source ~/.virtualenvs/singer-python/bin/activate
+pip install -U pip
+set -x
+echo $VIRTUAL_ENV
+python3 --version
+pip -V
+set +x
+make install

--- a/bin/circle_test
+++ b/bin/circle_test
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+source ~/.virtualenvs/singer-python/bin/activate
+
+python --version
+pip -V
+pip freeze
+
+make

--- a/circle.yml
+++ b/circle.yml
@@ -2,10 +2,6 @@ machine:
   python:
     version: 3.6.0
 
-dependencies:
-  pre:
-    - pip install pylint
-
 test:
-  post:
-    - pylint singer -d missing-docstring,broad-except,bare-except,too-many-return-statements,too-many-branches,too-many-arguments,no-else-return,too-few-public-methods,fixme,protected-access,too-many-locals,inconsistent-return-statements
+  override:
+    - make

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
-machine:
-  python:
-    version: 3.6.0
+dependencies:
+  override:
+    - bin/circle_deps
 
 test:
   override:
-    - make
+    - bin/circle_test

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,12 @@ setup(name="singer-python",
           'python-dateutil>=2.6.0',
           'backoff==1.3.2',
       ],
+      extras_require={
+          'dev': [
+              'pylint',
+              'nose'
+          ]
+      },
       packages=find_packages(),
       package_data = {
           'singer': [

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -1,8 +1,10 @@
 import sys
-import simplejson as json
-import singer.utils as u
+
 import dateutil
 import pytz
+import simplejson as json
+
+import singer.utils as u
 
 class Message(object):
     '''Base class for messages.'''
@@ -197,6 +199,8 @@ def parse_message(msg):
     elif msg_type == 'ACTIVATE_VERSION':
         return ActivateVersionMessage(stream=_required_key(obj, 'stream'),
                                       version=_required_key(obj, 'version'))
+    else:
+        return None
 
 
 def format_message(message):

--- a/singer/schema.py
+++ b/singer/schema.py
@@ -28,6 +28,7 @@ class Schema(object):  # pylint: disable=too-many-instance-attributes
 
     '''
 
+    # pylint: disable=too-many-locals
     def __init__(self, type=None, format=None, properties=None, items=None,
                  selected=None, inclusion=None, description=None, minimum=None,
                  maximum=None, exclusiveMinimum=None, exclusiveMaximum=None,

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -79,8 +79,8 @@ def update_state(state, entity, dtime):
         state[entity] = dtime
 
 
-def parse_args(required_config_keys):
-    '''Parse standard command-line args.
+def get_default_args_parser():
+    '''Create parser for standard command-line args.
 
     Parses the command-line arguments mentioned in the SPEC and the
     BEST_PRACTICES documents:
@@ -118,6 +118,29 @@ def parse_args(required_config_keys):
         '-d', '--discover',
         action='store_true',
         help='Do schema discovery')
+
+    return parser
+
+def parse_args(required_config_keys, parser=None):
+    '''Parse standard (and extended) command-line args.
+
+    By default it will create a parser using get_default_args_parser. If
+    you need more args you may call that function yourself, extend the
+    returned parser, and then pass it in. Failing to do so will result in
+    undefined behavior.
+
+    Also checks the config arg for validity using the required_config_keys
+    parameter.
+
+    See the docs for get_default_args_parser for further information.
+
+    Returns the parsed args object from argparse. For arguments that point
+    to JSON files (config, state, properties), we will automatically load
+    and parse the JSON file.
+    '''
+
+    if parser is None:
+        parser = get_default_args_parser()
 
     args = parser.parse_args()
     if args.config:

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -79,8 +79,8 @@ def update_state(state, entity, dtime):
         state[entity] = dtime
 
 
-def get_default_args_parser():
-    '''Create parser for standard command-line args.
+def parse_args(required_config_keys):
+    '''Parse standard command-line args.
 
     Parses the command-line arguments mentioned in the SPEC and the
     BEST_PRACTICES documents:
@@ -118,29 +118,6 @@ def get_default_args_parser():
         '-d', '--discover',
         action='store_true',
         help='Do schema discovery')
-
-    return parser
-
-def parse_args(required_config_keys, parser=None):
-    '''Parse standard (and extended) command-line args.
-
-    By default it will create a parser using get_default_args_parser. If
-    you need more args you may call that function yourself, extend the
-    returned parser, and then pass it in. Failing to do so will result in
-    undefined behavior.
-
-    Also checks the config arg for validity using the required_config_keys
-    parameter.
-
-    See the docs for get_default_args_parser for further information.
-
-    Returns the parsed args object from argparse. For arguments that point
-    to JSON files (config, state, properties), we will automatically load
-    and parse the JSON file.
-    '''
-
-    if parser is None:
-        parser = get_default_args_parser()
 
     args = parser.parse_args()
     if args.config:


### PR DESCRIPTION
Motivation
----------

Because the parser is built and then immediately used it is not open for
extension. This allows taps to get the parser and then extend it with
their own options.

Prior behavior is preserved through the use of an optional parser arg to
the utils.parse_args function.

Also adds a CONTRIBUTING document and aligns circle build with dev.