### PR TITLE
Parse to UTC for datetime transform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(name="singer-python",
       url="http://singer.io",
       install_requires=[
           'jsonschema==2.6.0',
-          'pendulum==1.2.0',
           'simplejson==3.11.1',
           'python-dateutil>=2.6.0',
           'backoff==1.3.2',

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(name="singer-python",
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       url="http://singer.io",
       install_requires=[
+          'pytz==2018.4',
           'jsonschema==2.6.0',
           'simplejson==3.11.1',
           'python-dateutil>=2.6.0',

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -1,6 +1,6 @@
 import sys
 
-import dateutil
+import dateutil.parser
 import pytz
 import simplejson as json
 

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -1,8 +1,7 @@
 import datetime
-import pendulum
 from jsonschema import RefResolver
 from singer.logger import get_logger
-from singer.utils import strftime
+from singer.utils import (strftime, strptime_to_utc)
 
 LOGGER = get_logger()
 
@@ -19,8 +18,9 @@ VALID_DATETIME_FORMATS = [
 
 def string_to_datetime(value):
     try:
-        return strftime(pendulum.parse(value))
-    except:
+        return strftime(strptime_to_utc(value))
+    except Exception as ex:
+        LOGGER.error(ex)
         return None
 
 

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -4,7 +4,7 @@ import datetime
 import functools
 import json
 import time
-import dateutil
+import dateutil.parser
 import pytz
 import backoff as backoff_module
 
@@ -28,6 +28,13 @@ def strptime(dtime):
         return datetime.datetime.strptime(dtime, DATETIME_FMT)
     except Exception:
         return datetime.datetime.strptime(dtime, DATETIME_PARSE)
+
+def strptime_to_utc(dtimestr):
+    d_object = dateutil.parser.parse(dtimestr)
+    if d_object.tzinfo is None:
+        return d_object.replace(tzinfo=pytz.UTC)
+    else:
+        return d_object.astimezone(tz=pytz.UTC)
 
 def strftime(dtime, format_str=DATETIME_FMT):
     if dtime.utcoffset() != datetime.timedelta(0):

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -12,6 +12,7 @@ from singer.catalog import Catalog
 
 DATETIME_PARSE = "%Y-%m-%dT%H:%M:%SZ"
 DATETIME_FMT = "%04Y-%m-%dT%H:%M:%S.%fZ"
+DATETIME_FMT_MAC = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 def now():
     return datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
@@ -39,7 +40,10 @@ def strptime_to_utc(dtimestr):
 def strftime(dtime, format_str=DATETIME_FMT):
     if dtime.utcoffset() != datetime.timedelta(0):
         raise Exception("datetime must be pegged at UTC tzoneinfo")
-    return dtime.strftime(format_str)
+    dt_str = dtime.strftime(format_str)
+    if dt_str.startswith('4Y'):
+        dt_str = dtime.strftime(DATETIME_FMT_MAC)
+    return dt_str
 
 def ratelimit(limit, every):
     def limitdecorator(func):

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -67,6 +67,12 @@ class TestTransform(unittest.TestCase):
         trans.integer_datetime_fmt = UNIX_SECONDS_INTEGER_DATETIME_PARSING
         self.assertIsNone(trans._transform_datetime('cat'))
 
+    def test_datetime_string_with_timezone(self):
+        schema = {"type": "string", "format": "date-time"}
+        string_datetime = "2017-03-18T07:00:05-0700"
+        transformed_string_datetime = "2017-03-18T14:00:05.000000Z"
+        self.assertEqual(transformed_string_datetime, transform(string_datetime, schema))
+
     def test_datetime_fractional_seconds_transform(self):
         schema = {"type": "string", "format": "date-time"}
         string_datetime = "2017-01-01T00:00:00.123000Z"


### PR DESCRIPTION
The transformer requires datetime strings to be pegged at UTC, or it fails. This causes datetime strings with timezones to fail, since they have a time zone attached and aren't being shifted.

This adds a function to utils that tries to parse and peg at UTC before passing into `strftime` and uses it within `string_to_datetime` in `transform.py`.