### PR TITLE
Fix/strftime write record

### DIFF
--- a/singer/messages.py
+++ b/singer/messages.py
@@ -60,7 +60,7 @@ class RecordMessage(Message):
             result['version'] = self.version
         if self.time_extracted:
             as_utc = self.time_extracted.astimezone(pytz.utc)
-            result['time_extracted'] = as_utc.strftime(u.DATETIME_FMT)
+            result['time_extracted'] = u.strftime(as_utc)
         return result
 
     def __str__(self):

--- a/tests/test_singer.py
+++ b/tests/test_singer.py
@@ -36,6 +36,7 @@ class TestSinger(unittest.TestCase):
         self.assertEqual(message, expected)
 
     def test_extraction_time_strftime(self):
+        """ Test that we're not corrupting timestamps with cross platform parsing. (Test case for OSX, specifically) """
         message = singer.RecordMessage(
             record={'name': 'foo'},
             stream='users',

--- a/tests/test_singer.py
+++ b/tests/test_singer.py
@@ -35,6 +35,16 @@ class TestSinger(unittest.TestCase):
         print(expected)
         self.assertEqual(message, expected)
 
+    def test_extraction_time_strftime(self):
+        message = singer.RecordMessage(
+            record={'name': 'foo'},
+            stream='users',
+            version=2,
+            time_extracted=dateutil.parser.parse("1970-01-02T00:00:00.000Z"))
+        expected = "{'type': 'RECORD', 'stream': 'users', 'record': {'name': 'foo'}, 'version': 2, 'time_extracted': '1970-01-02T00:00:00.000000Z'}"
+        self.assertEqual(str(message), expected)
+
+
     def test_parse_message_record_missing_record(self):
         with self.assertRaises(Exception):
             singer.parse_message('{"type": "RECORD", "stream": "users"}')

--- a/tests/test_singer.py
+++ b/tests/test_singer.py
@@ -42,8 +42,8 @@ class TestSinger(unittest.TestCase):
             stream='users',
             version=2,
             time_extracted=dateutil.parser.parse("1970-01-02T00:00:00.000Z"))
-        expected = "{'type': 'RECORD', 'stream': 'users', 'record': {'name': 'foo'}, 'version': 2, 'time_extracted': '1970-01-02T00:00:00.000000Z'}"
-        self.assertEqual(str(message), expected)
+        expected = "1970-01-02T00:00:00.000000Z"
+        self.assertEqual(message.asdict()["time_extracted"], expected)
 
 
     def test_parse_message_record_missing_record(self):


### PR DESCRIPTION
The write_record function appears to be using a date format that can cause issues on OSX. This PR changes it to use the `strftime` defined in `singer.utils` that has handling for cross platform string formatting.