### PR TITLE
Fix/error reporting in parsing

### DIFF
--- a/singer/transform.py
+++ b/singer/transform.py
@@ -20,7 +20,7 @@ def string_to_datetime(value):
     try:
         return strftime(strptime_to_utc(value))
     except Exception as ex:
-        LOGGER.error(ex)
+        LOGGER.error("{}, ({}), replacing with null.".format(ex, value))
         return None
 
 
@@ -166,6 +166,9 @@ class Transformer:
         return all(successes), result
 
     def _transform_datetime(self, value):
+        if value is None or value == "":
+            return None # Short circuit in the case of null or empty
+
         if self.integer_datetime_fmt not in VALID_DATETIME_FORMATS:
             raise Exception("Invalid integer datetime parsing option")
 

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -20,7 +20,7 @@ def string_to_datetime(value):
     try:
         return strftime(strptime_to_utc(value))
     except Exception as ex:
-        LOGGER.error("{}, ({}), replacing with null.".format(ex, value))
+        LOGGER.warning("{}, ({})".format(ex, value))
         return None
 
 
@@ -167,7 +167,7 @@ class Transformer:
 
     def _transform_datetime(self, value):
         if value is None or value == "":
-            return None # Short circuit in the case of null or empty
+            return None # Short circuit in the case of null or empty string
 
         if self.integer_datetime_fmt not in VALID_DATETIME_FORMATS:
             raise Exception("Invalid integer datetime parsing option")

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -20,7 +20,7 @@ def string_to_datetime(value):
     try:
         return strftime(strptime_to_utc(value))
     except Exception as ex:
-        LOGGER.warning("{}, ({})".format(ex, value))
+        LOGGER.warning("%s, (%s)", ex, value)
         return None
 
 


### PR DESCRIPTION
In the case that a value comes through as `None` or `''` (empty string) for a datetime schema, the transformer was logging an error level log line, while this case was actually being parsed successfully to `None` (null) if the schema is marked nullable. 

This short circuits datetime parsing in the case that `None` or `''` get passed in as a value to avoid this message, and improves the log message on parse failure by reducing the level to warning and providing the failed value in parentheses after the message.

The message was made warning since the schema may have fallbacks that will cause the field to parse successfully (like `anyOf` with a datetime and a raw string type included).