### PR TITLE
Feature/transform filters using metadata

### DIFF
--- a/singer/transform.py
+++ b/singer/transform.py
@@ -1,7 +1,7 @@
 import datetime
-import singer.metadata
-
 from jsonschema import RefResolver
+
+import singer.metadata
 from singer.logger import get_logger
 from singer.utils import (strftime, strptime_to_utc)
 
@@ -78,11 +78,13 @@ class Transformer:
 
     def log_warning(self):
         if self.filtered:
-            LOGGER.info("Filtered %s paths during transforms:\n\t%s",
-                           len(self.filtered),
-                           "\n\t".join(sorted(self.filtered)))
+            LOGGER.info("Filtered %s paths during transforms "
+                        "as they were unsupported or not selected:\n\t%s",
+                        len(self.filtered),
+                        "\n\t".join(sorted(self.filtered)))
             # Output list format to parse for reporting
-            LOGGER.info("Filtered paths list: %s as they were unsupported or not selected", sorted(self.filtered))
+            LOGGER.info("Filtered paths list: %s",
+                        sorted(self.filtered))
 
         if self.removed:
             LOGGER.warning("Removed %s paths during transforms:\n\t%s",
@@ -105,7 +107,7 @@ class Transformer:
                 if inclusion == 'automatic':
                     continue
 
-                if selected == False:
+                if selected is False:
                     data.pop(field_name, None)
                     self.filtered.add(field_name)
 
@@ -273,7 +275,8 @@ class Transformer:
             return False, None
 
 
-def transform(data, schema, integer_datetime_fmt=NO_INTEGER_DATETIME_PARSING, pre_hook=None, metadata=None):
+def transform(data, schema, integer_datetime_fmt=NO_INTEGER_DATETIME_PARSING,
+              pre_hook=None, metadata=None):
     """
     Applies schema (and integer_datetime_fmt, if supplied) to data, transforming
     each field in data to the type specified in schema. If no type matches a

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -78,11 +78,11 @@ class Transformer:
 
     def log_warning(self):
         if self.filtered:
-            LOGGER.warning("Filtered %s paths during transforms:\n\t%s",
+            LOGGER.info("Filtered %s paths during transforms:\n\t%s",
                            len(self.filtered),
                            "\n\t".join(sorted(self.filtered)))
             # Output list format to parse for reporting
-            LOGGER.warning("Filtered paths list: %s as they were unsupported or not selected", sorted(self.filtered))
+            LOGGER.info("Filtered paths list: %s as they were unsupported or not selected", sorted(self.filtered))
 
         if self.removed:
             LOGGER.warning("Removed %s paths during transforms:\n\t%s",

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -1,4 +1,6 @@
 import datetime
+import singer.metadata
+
 from jsonschema import RefResolver
 from singer.logger import get_logger
 from singer.utils import (strftime, strptime_to_utc)
@@ -71,9 +73,17 @@ class Transformer:
         self.integer_datetime_fmt = integer_datetime_fmt
         self.pre_hook = pre_hook
         self.removed = set()
+        self.filtered = set()
         self.errors = []
 
     def log_warning(self):
+        if self.filtered:
+            LOGGER.warning("Filtered %s paths during transforms:\n\t%s",
+                           len(self.filtered),
+                           "\n\t".join(sorted(self.filtered)))
+            # Output list format to parse for reporting
+            LOGGER.warning("Filtered paths list: %s as they were unsupported or not selected", sorted(self.filtered))
+
         if self.removed:
             LOGGER.warning("Removed %s paths during transforms:\n\t%s",
                            len(self.removed),
@@ -87,7 +97,27 @@ class Transformer:
     def __exit__(self, *args):
         self.log_warning()
 
-    def transform(self, data, schema):
+    def filter_data_by_metadata(self, data, metadata):
+        if isinstance(data, dict) and metadata:
+            for field_name in list(data.keys()):
+                selected = singer.metadata.get(metadata, ('properties', field_name), 'selected')
+                inclusion = singer.metadata.get(metadata, ('properties', field_name), 'inclusion')
+                if inclusion == 'automatic':
+                    continue
+
+                if selected == False:
+                    data.pop(field_name, None)
+                    self.filtered.add(field_name)
+
+                if inclusion == 'unsupported':
+                    data.pop(field_name, None)
+                    self.filtered.add(field_name)
+
+        return data
+
+    def transform(self, data, schema, metadata=None):
+        data = self.filter_data_by_metadata(data, metadata)
+
         success, transformed_data = self.transform_recur(data, schema, [])
         if not success:
             raise SchemaMismatch(self.errors)
@@ -243,7 +273,7 @@ class Transformer:
             return False, None
 
 
-def transform(data, schema, integer_datetime_fmt=NO_INTEGER_DATETIME_PARSING, pre_hook=None):
+def transform(data, schema, integer_datetime_fmt=NO_INTEGER_DATETIME_PARSING, pre_hook=None, metadata=None):
     """
     Applies schema (and integer_datetime_fmt, if supplied) to data, transforming
     each field in data to the type specified in schema. If no type matches a
@@ -262,7 +292,7 @@ def transform(data, schema, integer_datetime_fmt=NO_INTEGER_DATETIME_PARSING, pr
     returns the transformed data to be fed into the _transform function.
     """
     transformer = Transformer(integer_datetime_fmt, pre_hook)
-    return transformer.transform(data, schema)
+    return transformer.transform(data, schema, metadata=metadata)
 
 def _transform_datetime(value, integer_datetime_fmt=NO_INTEGER_DATETIME_PARSING):
     transformer = Transformer(integer_datetime_fmt)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -252,6 +252,49 @@ class TestTransform(unittest.TestCase):
         empty_data = {'addrs': {}}
         self.assertDictEqual(empty_data, transform(empty_data, schema))
 
+class TestTransformsWithMetadata(unittest.TestCase):
+
+    def test_drops_no_data_when_not_dict(self):
+        schema = {"type": "string"}
+        metadata = {}
+        string_value = "hello"
+        self.assertEqual(string_value, transform(string_value, schema, NO_INTEGER_DATETIME_PARSING, metadata=metadata))
+
+    def test_keeps_selected_data_from_dicts(self):
+        schema = {"type": "object",
+                  "properties": { "name": {"type": "string"}}}
+        metadata = {('properties','name'): {"selected": True}}
+        dict_value = {"name": "chicken"}
+        self.assertEqual({"name": "chicken"}, transform(dict_value, schema, NO_INTEGER_DATETIME_PARSING, metadata=metadata))
+
+    def test_keeps_automatic_data_from_dicts(self):
+        schema = {"type": "object",
+                  "properties": { "name": {"type": "string"}}}
+        metadata = {('properties','name'): {"inclusion": "automatic"}}
+        dict_value = {"name": "chicken"}
+        self.assertEqual({"name": "chicken"}, transform(dict_value, schema, NO_INTEGER_DATETIME_PARSING, metadata=metadata))
+
+    def test_keeps_fields_without_metadata(self):
+        schema = {"type": "object",
+                  "properties": { "name": {"type": "string"}}}
+        metadata = {('properties','age'): {"inclusion": "automatic"}}
+        dict_value = {"name": "chicken"}
+        self.assertEqual({"name": "chicken"}, transform(dict_value, schema, NO_INTEGER_DATETIME_PARSING, metadata=metadata))
+
+    def test_drops_fields_which_are_unselected(self):
+        schema = {"type": "object",
+                  "properties": { "name": {"type": "string"}}}
+        metadata = {('properties','name'): {"selected": False}}
+        dict_value = {"name": "chicken"}
+        self.assertEqual({}, transform(dict_value, schema, NO_INTEGER_DATETIME_PARSING, metadata=metadata))
+
+    def test_drops_fields_which_are_unsupported(self):
+        schema = {"type": "object",
+                  "properties": { "name": {"type": "string"}}}
+        metadata = {('properties','name'): {"inclusion": "unsupported"}}
+        dict_value = {"name": "chicken"}
+        self.assertEqual({}, transform(dict_value, schema, NO_INTEGER_DATETIME_PARSING, metadata=metadata))
+
 class TestResolveSchemaReferences(unittest.TestCase):
     def test_internal_refs_resolve(self):
         schema =  {"type": "object",


### PR DESCRIPTION
This branch is to add metadata awareness to singer-python's transform functionality. That way, it will be able to detect unselected or unsupported fields and drop them from the data without the tap having to do anything other than pass in the metadata dictionary that it already has.

Additionally, this adds the filtered fields that are dropped in this way to the logs to provide a mechanism for log analysis, much like the removed fields that currently exist.