### PR TITLE
Use disable_existing_loggers in logger

### DIFF
--- a/singer/logger.py
+++ b/singer/logger.py
@@ -7,7 +7,13 @@ def get_logger():
     """Return a Logger instance appropriate for using in a Tap or a Target."""
     this_dir, _ = os.path.split(__file__)
     path = os.path.join(this_dir, 'logging.conf')
-    logging.config.fileConfig(path)
+    # See
+    # https://docs.python.org/3.5/library/logging.config.html#logging.config.fileConfig
+    # for a discussion of why or why not to set disable_existing_loggers
+    # to False. The long and short of it is that if you don't set it to
+    # False it ruins external module's abilities to use the logging
+    # facility.
+    logging.config.fileConfig(path, disable_existing_loggers=False)
     return logging.getLogger()
 
 


### PR DESCRIPTION
Motivation
----------

This allows external modules to use the logging facilities.