### PR TITLE
Test multiple Python versions using Travis-CI and Conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language:
+  python
+env:
+  matrix:
+  - PYTHON_VERSION="3.4"
+  - PYTHON_VERSION="3.4.3"
+  - PYTHON_VERSION="3.5"
+  - PYTHON_VERSION="3.5.2"
+  - PYTHON_VERSION="3.6"
+  - PYTHON_VERSION="3.7"
+install:
+  - sudo apt-get update
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - conda create -q -n test-environment python=$PYTHON_VERSION nose
+  - source activate test-environment
+  - python3 -m pip install .
+script:
+  - nosetests -v

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .DEFAULT_GOAL := test
 
 check_prereqs:
-	bash -c '[[ -n $$VIRTUAL_ENV ]]'
-	bash -c '[[ $$(python3 --version) == *3.4.3* ]]'
+	bash -c '[[ -n $${VIRTUAL_ENV:-$${CONDA_PREFIX}} ]]'
+	bash -c '[[ $$(python3 --version 2>&1) == *3.4.3* ]]'
 
 install: check_prereqs
 	python3 -m pip install -e '.[dev]'


### PR DESCRIPTION
1. added .travis.yml for testing multiple python versions using Travis-CI and Conda - https://travis-ci.org/OriHoch/singer-python/builds/444822592
2. minor changes to check_prereqs to support running using Conda environment which is slightly different then virtualenv
