### PR TITLE
Update strftime to fallback to non %04Y formatting on Windows

### DIFF
--- a/singer/utils.py
+++ b/singer/utils.py
@@ -14,7 +14,7 @@ from singer.catalog import Catalog
 
 DATETIME_PARSE = "%Y-%m-%dT%H:%M:%SZ"
 DATETIME_FMT = "%04Y-%m-%dT%H:%M:%S.%fZ"
-DATETIME_FMT_MAC = "%Y-%m-%dT%H:%M:%S.%fZ"
+DATETIME_FMT_SAFE = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 def now():
     return datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
@@ -67,9 +67,15 @@ def strptime_to_utc(dtimestr):
 def strftime(dtime, format_str=DATETIME_FMT):
     if dtime.utcoffset() != datetime.timedelta(0):
         raise Exception("datetime must be pegged at UTC tzoneinfo")
-    dt_str = dtime.strftime(format_str)
-    if dt_str.startswith('4Y'):
-        dt_str = dtime.strftime(DATETIME_FMT_MAC)
+
+    dt_str = None
+    try:
+        dt_str = dtime.strftime(format_str)
+        if dt_str.startswith('4Y'):
+            dt_str = dtime.strftime(DATETIME_FMT_SAFE)
+    except ValueError:
+        dt_str = dtime.strftime(DATETIME_FMT_SAFE)
+
     return dt_str
 
 def ratelimit(limit, every):


### PR DESCRIPTION
Fix https://github.com/singer-io/singer-python/issues/86

Update `strftime` to fallback to non-`%04Y` formatting on Windows 10

The current tests are sufficient to fail before on Windows and pass after this patch, `nosetests tests/test_utils.py`