### PR TITLE
Retain Argument Paths

### DIFF
--- a/singer/utils.py
+++ b/singer/utils.py
@@ -165,14 +165,18 @@ def parse_args(required_config_keys):
 
     args = parser.parse_args()
     if args.config:
+        setattr(args, 'config_path', args.config)
         args.config = load_json(args.config)
     if args.state:
+        setattr(args, 'state_path', args.state)
         args.state = load_json(args.state)
     else:
         args.state = {}
     if args.properties:
+        setattr(args, 'properties_path', args.properties)
         args.properties = load_json(args.properties)
     if args.catalog:
+        setattr(args, 'catalog_path', args.catalog)
         args.catalog = Catalog.load(args.catalog)
 
     check_config(args.config, required_config_keys)


### PR DESCRIPTION
Currently, `parse_args` overwrites `config` and other parsed arguments, a file path, with the parsed JSON. This makes the original file path inaccessible. This PR adds allows for accessing the original argument / file path.

For context, for a tap which needs the refresh token saved after each auth, I need to save the changes to the config file, which means I need access to the config path.

Functional Testing
- Running `parse_args` the args for a tap and accessing the `config_path`