### PR TITLE
Init logger

### DIFF
--- a/singer/logger.py
+++ b/singer/logger.py
@@ -8,6 +8,7 @@ _INIT_LOGGER = True
 
 def init_logger():
     """Initialize the Logger instance."""
+    # pylint: disable=W0603
     global _INIT_LOGGER
 
     this_dir, _ = os.path.split(__file__)

--- a/singer/logger.py
+++ b/singer/logger.py
@@ -3,10 +3,16 @@ import logging.config
 import os
 
 
-def get_logger():
-    """Return a Logger instance appropriate for using in a Tap or a Target."""
+_INIT_LOGGER = True
+
+
+def init_logger():
+    """Initialize the Logger instance."""
+    global _INIT_LOGGER
+
     this_dir, _ = os.path.split(__file__)
-    path = os.path.join(this_dir, 'logging.conf')
+    path = os.path.join(this_dir, "logging.conf")
+
     # See
     # https://docs.python.org/3.5/library/logging.config.html#logging.config.fileConfig
     # for a discussion of why or why not to set disable_existing_loggers
@@ -14,6 +20,16 @@ def get_logger():
     # False it ruins external module's abilities to use the logging
     # facility.
     logging.config.fileConfig(path, disable_existing_loggers=False)
+
+    # Only initialize the logger once.
+    _INIT_LOGGER = False
+
+
+def get_logger():
+    """Return a Logger instance appropriate for using in a Tap or a Target."""
+    if _INIT_LOGGER:
+        init_logger()
+
     return logging.getLogger()
 
 


### PR DESCRIPTION
Initialize the singer root logger once

Only initialize the logger once, and only if the _INIT_LOGGER module private
variable is True. The reason for this is to allow client applications to
override logging with custom formatters (& more) when necessary. For instance,
to use eliot[1] to log but take advantage of the metrics and timers supplied by
singer-python.

[1] eliot: https://eliot.readthedocs.io/en/stable/

Disable pylint global warning for _INIT_LOGGER

An alternative would be to cache the results of get_logger, but this feels
cleaner and more explicit to me.