### PR TITLE
Add update_config_file() and unittests

### DIFF
--- a/singer/utils.py
+++ b/singer/utils.py
@@ -185,6 +185,9 @@ def check_config(config, required_keys):
     if missing_keys:
         raise Exception("Config is missing required keys: {}".format(missing_keys))
 
+def update_config_file(config_path, new_config):
+    with open(config_path, 'w') as output:
+        output.write(json.dumps(new_config, indent=2))
 
 def backoff(exceptions, giveup):
     """Decorates a function to retry up to 5 times using an exponential backoff

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,3 +33,22 @@ class TestHandleException(unittest.TestCase):
         def foo():
             raise RuntimeError("foo")
         self.assertRaises(RuntimeError, foo)
+
+class TestUpdateConfig(unittest.TestCase):
+    def test_file_changed(self):
+        original_config = {'key_a': 'val_a'}
+
+        with open('config.json', 'w') as file:
+            file.write(json.dumps(original_config))
+
+        changed_config = {'key_b': 'val_b'}
+
+        u.update_config_file('config.json', changed_config)
+
+        read_config = u.load_json('config.json')
+
+        self.assertEqual(changed_config.get('key_b'), read_config.get('key_b'))
+
+    def tearDown(self):
+        import os
+        os.remove('config.json')


### PR DESCRIPTION
This commit adds an example of how someone could write a function to update a config file, as mentioned [in this PR](https://github.com/singer-io/getting-started/pull/49). 