### PR TITLE
Support pattern properties in object schemas

### DIFF
--- a/singer/schema.py
+++ b/singer/schema.py
@@ -19,6 +19,7 @@ STANDARD_KEYS = [
     'type',
     'additionalProperties',
     'anyOf',
+    'patternProperties',
 ]
 
 
@@ -35,7 +36,7 @@ class Schema():  # pylint: disable=too-many-instance-attributes
                  selected=None, inclusion=None, description=None, minimum=None,
                  maximum=None, exclusiveMinimum=None, exclusiveMaximum=None,
                  multipleOf=None, maxLength=None, minLength=None, additionalProperties=None,
-                 anyOf=None):
+                 anyOf=None, patternProperties=None):
 
         self.type = type
         self.properties = properties
@@ -53,6 +54,7 @@ class Schema():  # pylint: disable=too-many-instance-attributes
         self.anyOf = anyOf
         self.format = format
         self.additionalProperties = additionalProperties
+        self.patternProperties = patternProperties
 
     def __str__(self):
         return json.dumps(self.to_dict())
@@ -79,8 +81,9 @@ class Schema():  # pylint: disable=too-many-instance-attributes
 
         if self.items is not None:
             result['items'] = self.items.to_dict()  # pylint: disable=no-member
+
         for key in STANDARD_KEYS:
-            if self.__dict__[key] is not None:
+            if self.__dict__.get(key) is not None:
                 result[key] = self.__dict__[key]
 
         return result

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -171,18 +171,18 @@ class Transformer:
             return False, data
 
         # Don't touch an empty schema
-        if schema == {}:
+        if schema == {} and not pattern_properties:
             return True, data
 
         result = {}
         successes = []
         for key, value in data.items():
             # patternProperties are a map of {"pattern": { schema...}}
-            pattern_schemas = [s for p, s
+            pattern_schemas = [schema for pattern, schema
                                in (pattern_properties or {}).items()
-                               if re.match(p, key)]
-            if key in schema or pattern_schemas:
-                sub_schema = schema[key] if not pattern_schemas else {'anyOf': pattern_schemas}
+                               if re.match(pattern, key)]
+            if key in schema or any(pattern_schemas):
+                sub_schema = schema.get(key, {'anyOf': pattern_schemas})
                 success, subdata = self.transform_recur(value, sub_schema, path + [key])
                 successes.append(success)
                 result[key] = subdata

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -177,10 +177,10 @@ class Transformer:
         result = {}
         successes = []
         for key, value in data.items():
-            pattern_schemas = []
-            for pattern, pschema in (pattern_properties or {}).items():
-                if re.match(pattern, key):
-                    pattern_schemas.append(pschema)
+            # patternProperties are a map of {"pattern": { schema...}}
+            pattern_schemas = [s for p, s
+                               in (pattern_properties or {}).items()
+                               if re.match(p, key)]
             if key in schema or pattern_schemas:
                 sub_schema = schema[key] if not pattern_schemas else {'anyOf': pattern_schemas}
                 success, subdata = self.transform_recur(value, sub_schema, path + [key])

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -181,7 +181,7 @@ class Transformer:
             pattern_schemas = [schema for pattern, schema
                                in (pattern_properties or {}).items()
                                if re.match(pattern, key)]
-            if key in schema or any(pattern_schemas):
+            if key in schema or pattern_schemas:
                 sub_schema = schema.get(key, {'anyOf': pattern_schemas})
                 success, subdata = self.transform_recur(value, sub_schema, path + [key])
                 successes.append(success)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -372,7 +372,7 @@ class TestPatternProperties(unittest.TestCase):
     def test_pattern_properties_match_multiple(self):
         schema = {"type": "object",
                   "patternProperties": { ".+?cost": {"type": "number"},
-                                         ".+[^(cost)]": {"type": "string"}}}
+                                         ".+(?<!cost)$": {"type": "string"}}}
         dict_value = {"name": "chicken", "unit_cost": 1.45, "SKU": '123456'}
         expected = dict(dict_value)
         self.assertEqual(expected, transform(dict_value, schema))

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -360,3 +360,19 @@ class TestResolveSchemaReferences(unittest.TestCase):
         result = resolve_schema_references(schema, refs)
         self.assertEqual(result['properties']['name']['type'], "string")
         self.assertEqual(result['properties']['name']['still_here'], "yep")
+
+class TestPatternProperties(unittest.TestCase):
+    def test_pattern_properties_match(self):
+        schema = {"type": "object",
+                  "patternProperties": { ".+": {"type": "string"}}}
+        dict_value = {"name": "chicken", "unit_cost": '1.45', "SKU": '123456'}
+        expected = dict(dict_value)
+        self.assertEqual(expected, transform(dict_value, schema))
+
+    def test_pattern_properties_match_multiple(self):
+        schema = {"type": "object",
+                  "patternProperties": { ".+?cost": {"type": "number"},
+                                         ".+[^(cost)]": {"type": "string"}}}
+        dict_value = {"name": "chicken", "unit_cost": 1.45, "SKU": '123456'}
+        expected = dict(dict_value)
+        self.assertEqual(expected, transform(dict_value, schema))


### PR DESCRIPTION
JSON Schema supports object schemas having the keys `additionalProperties` and `patternProperties` described in the Draft 4 validation document [here](https://tools.ietf.org/html/draft-fge-json-schema-validation-00).

### Maintained

- Empty object schemas still validate against anything

### Added

#### patternProperties

PatternProperties are a JSON object of the form `{"regex_pattern": {...schema...}}`. For example, a simple "catch-all" schema would look like this:

```
{
    "type": "object",
    "patternProperties": {
        ".+": {},
        ...
    }
}
```

This is useful in the event that you want the schema to validate against all keys, but override using `properties` for more specific types (like date-times).

**Principles**

- `properties` takes precedence
- An empty `properties` and `patternProperties` is treated as an empty schema and validates against all
- Regex ordering cannot be guaranteed (since the JSON Schema spec says "object" explicitly), so regexes should be distinct as possible for mixing types, to be deterministic