### PR TITLE
Resolve references in anyOf schema keys.

### DIFF
--- a/singer/transform.py
+++ b/singer/transform.py
@@ -52,6 +52,7 @@ class SchemaKey:
     items = "items"
     properties = "properties"
     pattern_properties = "patternProperties"
+    any_of = 'anyOf'
 
 class Error:
     def __init__(self, path, data, schema=None):
@@ -355,5 +356,9 @@ def _resolve_schema_references(schema, resolver):
 
     if SchemaKey.items in schema:
         schema[SchemaKey.items] = _resolve_schema_references(schema[SchemaKey.items], resolver)
+
+    if SchemaKey.any_of in schema:
+        for i, element in enumerate(schema[SchemaKey.any_of]):
+            schema[SchemaKey.any_of][i] = _resolve_schema_references(element, resolver)
 
     return schema


### PR DESCRIPTION
I found that the `resolve_schema_references` method doesn't expand JSON schema references in `anyOf` blocks. I added a new `SchemaKey` to make sure we recursively expand those `$ref` blocks.

Are there other keys we should also think about (e.g. `allOf`, `oneOf`)? Is there a more generalized approach used elsewhere in Singer for navigating the tree we should consider? 