### PR TITLE
Filter nested properties based on metadata

### DIFF
--- a/singer/transform.py
+++ b/singer/transform.py
@@ -124,8 +124,8 @@ class Transformer:
                 data[field_name] = self.filter_data_by_metadata(field_data, metadata, breadcrumb)
 
         if isinstance(data, list) and metadata:
-            breadcrumb = parent + ('items', field_name)
-            data = [self.filter_data_by_metadata(d, metadata, breadcrumb) for d in data]
+            breadcrumb = parent + ('items',)
+            data = [self.filter_data_by_metadata(d, metadata, parent + ('items', )) for d in data]
 
         return data
 

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -113,7 +113,7 @@ class Transformer:
 
     def filter_data_by_metadata(self, data, metadata, parent=()):
         if isinstance(data, dict) and metadata:
-            for field_name, field_data in data.items():
+            for field_name in list(data.keys()):
                 breadcrumb = parent + ('properties', field_name)
                 selected = singer.metadata.get(metadata, breadcrumb, 'selected')
                 inclusion = singer.metadata.get(metadata, breadcrumb, 'inclusion')
@@ -121,10 +121,10 @@ class Transformer:
                     continue
 
                 if (selected is False) or (inclusion == 'unsupported'):
-                    data[field_name] = None
+                    data.pop(field_name, None)
                     self.filtered.add(breadcrumb_path(breadcrumb))
-
-                data[field_name] = self.filter_data_by_metadata(field_data, metadata, breadcrumb)
+                else:
+                    data[field_name] = self.filter_data_by_metadata(data[field_name], metadata, breadcrumb)
 
         if isinstance(data, list) and metadata:
             breadcrumb = parent + ('items',)

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -124,7 +124,8 @@ class Transformer:
                 data[field_name] = self.filter_data_by_metadata(field_data, metadata, breadcrumb)
 
         if isinstance(data, list) and metadata:
-            data = [self.filter_data_by_metadata(d, metadata, parent) for d in data]
+            breadcrumb = parent + ('items', field_name)
+            data = [self.filter_data_by_metadata(d, metadata, breadcrumb) for d in data]
 
         return data
 

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -36,6 +36,9 @@ def unix_seconds_to_datetime(value):
 
 
 def breadcrumb_path(breadcrumb):
+    """
+    Transform breadcrumb into familiar object dot-notation
+    """
     name = ".".join(breadcrumb)
     name = name.replace('properties.', '')
     name = name.replace('.items', '[]')


### PR DESCRIPTION
Not sure if this will be too big a change, but I wanted to be able to filter out nested properties based on metadata rather than just top level properties.

So if I have a field `billing_address` of type `object` with the properties `street`, `state`, `zip`, and `country`, I could have `selected: True` for `billing_address`, but `billing_address.street` could be `selected: False`.

The result would be the three other fields (`state`, `zip` and `country`) would be synced.

All tests pass - it shouldn't break any existing use cases because it will only filter out nested fields that are explicitly unselected or unsupported.