### PR TITLE
Pass kwargs to json.dumps in singer.format_message

### DIFF
--- a/singer/messages.py
+++ b/singer/messages.py
@@ -209,8 +209,10 @@ def parse_message(msg):
         return None
 
 
-def format_message(message):
-    return json.dumps(message.asdict(), use_decimal=True)
+def format_message(message, **kwargs):
+    return json.dumps(message.asdict(),
+                      use_decimal=kwargs.pop('use_decimal', True),
+                      **kwargs)
 
 
 def write_message(message):


### PR DESCRIPTION
Allow configuring json encoder by passing kwargs through
to json.dumps in singer.format_message. Use case is passing data
from pandas.DataFrame containing NaN to encode as `null`