### PR TITLE
Allow empty lists in get_standard_metadata

### DIFF
--- a/singer/metadata.py
+++ b/singer/metadata.py
@@ -26,11 +26,11 @@ def get_standard_metadata(schema=None, schema_name=None, key_properties=None,
                           valid_replication_keys=None, replication_method=None):
     mdata = {}
 
-    if key_properties:
+    if key_properties is not None:
         mdata = write(mdata, (), 'table-key-properties', key_properties)
     if replication_method:
         mdata = write(mdata, (), 'forced-replication-method', replication_method)
-    if valid_replication_keys:
+    if valid_replication_keys is not None:
         mdata = write(mdata, (), 'valid-replication-keys', valid_replication_keys)
     if schema:
         mdata = write(mdata, (), 'inclusion', 'available')

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -325,3 +325,11 @@ class TestStandardMetadata(unittest.TestCase):
         for obj in expected_metadata:
             if obj in test_value:
                 self.assertIn(obj, test_value)
+
+    def test_empty_key_properties_are_written(self):
+        mdata = get_standard_metadata(key_properties=[])
+        self.assertEqual(mdata, [{'breadcrumb': (), 'metadata': {'table-key-properties': []}}])
+
+    def test_empty_valid_replication_keys_are_written(self):
+        mdata = get_standard_metadata(valid_replication_keys=[])
+        self.assertEqual(mdata, [{'breadcrumb': (), 'metadata': {'valid-replication-keys': []}}])


### PR DESCRIPTION
Both `table-key-properties` and `valid-replication-keys` have `[]` as valid values. Since this is falsy, it was skipping the write when either was specified as an empty array.

This PR changes it to an explicit `None` check to allow empty arrays.