### PR TITLE
Add version to write_record method

### DIFF
--- a/singer/messages.py
+++ b/singer/messages.py
@@ -227,14 +227,15 @@ def write_message(message):
     sys.stdout.flush()
 
 
-def write_record(stream_name, record, stream_alias=None, time_extracted=None):
+def write_record(stream_name, record, stream_alias=None, time_extracted=None, version=None):
     """Write a single record for the given stream.
 
     write_record("users", {"id": 2, "email": "mike@stitchdata.com"})
     """
     write_message(RecordMessage(stream=(stream_alias or stream_name),
                                 record=record,
-                                time_extracted=time_extracted))
+                                time_extracted=time_extracted,
+                                version=version))
 
 
 def write_records(stream_name, records):


### PR DESCRIPTION
The write_record method lacks the support of a `version`.

Some tests give:
```
import singer

singer.write_record(stream_name="a", record={"hello": "world"})
{"type": "RECORD", "stream": "a", "record": {"hello": "world"}}

singer.write_record(stream_name="a", record={"hello": "world"}, version=None)
{"type": "RECORD", "stream": "a", "record": {"hello": "world"}}

singer.write_record(stream_name="a", record={"hello": "world"}, version="2019-01-01")
{"type": "RECORD", "stream": "a", "record": {"hello": "world"}, "version": "2019-01-01"}

singer.write_record(stream_name="a", record={"hello": "world"}, version=123456789)
{"type": "RECORD", "stream": "a", "record": {"hello": "world"}, "version": 123456789}
```