### PR TITLE
Allow passing literal JSON strings instead of file paths

### DIFF
--- a/singer/utils.py
+++ b/singer/utils.py
@@ -104,9 +104,13 @@ def chunk(array, num):
         yield array[i:i + num]
 
 
-def load_json(path):
-    with open(path) as fil:
-        return json.load(fil)
+def load_json(path_or_json):
+  try:
+    inline_config = json.loads(path_or_json)
+  except ValueError as e:
+    with open(path_or_json) as fil:
+      return json.load(fil)
+  return inline_config
 
 
 def update_state(state, entity, dtime):

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -105,12 +105,12 @@ def chunk(array, num):
 
 
 def load_json(path_or_json):
-  try:
-    inline_config = json.loads(path_or_json)
-  except ValueError as e:
-    with open(path_or_json) as fil:
-      return json.load(fil)
-  return inline_config
+    try:
+        inline_config = json.loads(path_or_json)
+    except ValueError:
+        with open(path_or_json) as fil:
+            return json.load(fil)
+    return inline_config
 
 
 def update_state(state, entity, dtime):


### PR DESCRIPTION
Extended `load_json` function in the `utils` to accept literal JSON strings instead of file paths. `load_json` will try to interpret the input string as JSON and fallback to interpret it as a file path when JSON parsing fails.

Closes #109 