### PR TITLE
Updates transform logging to only output the raw data in DEBUG

### DIFF
--- a/singer/statediff.py
+++ b/singer/statediff.py
@@ -46,8 +46,8 @@ def diff(oldstate, newstate):
 
     # Convert oldstate and newstate from a deeply nested dict into a
     # single-level dict, mapping a path to a value.
-    olddict = {k: v for (k, v) in paths(oldstate)}
-    newdict = {k: v for (k, v) in paths(newstate)}
+    olddict = dict(paths(oldstate))
+    newdict = dict(paths(newstate))
 
     # Build the list of all paths in both oldstate and newstate to iterate
     # over.

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -65,11 +65,15 @@ class Error:
     def tostr(self):
         path = ".".join(map(str, self.path))
         if self.schema:
-            msg = "does not match {}".format(self.schema)
+            if self.logging_level >= logging.INFO:
+                msg = "data does not match {}".format(self.schema)
+            else:
+                msg = "does not match {}".format(self.schema)
         else:
             msg = "not in schema"
+
         if self.logging_level >= logging.INFO:
-            output = "{}: data {}".format(path, msg)
+            output = "{}: {}".format(path, msg)
         else:
             output = "{}: {} {}".format(path, self.data, msg)
         return output

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import re
 from jsonschema import RefResolver
 
@@ -55,10 +56,11 @@ class SchemaKey:
     any_of = 'anyOf'
 
 class Error:
-    def __init__(self, path, data, schema=None):
+    def __init__(self, path, data, schema=None, logging_level=logging.INFO):
         self.path = path
         self.data = data
         self.schema = schema
+        self.logging_level = logging_level
 
     def tostr(self):
         path = ".".join(map(str, self.path))
@@ -66,8 +68,11 @@ class Error:
             msg = "does not match {}".format(self.schema)
         else:
             msg = "not in schema"
-
-        return "{}: {} {}".format(path, self.data, msg)
+        if self.logging_level >= logging.INFO:
+            f = "{}: data {}".format(path, msg)
+        else:
+            f = "{}: {} {}".format(path, self.data, msg)
+        return f
 
 
 class Transformer:
@@ -154,7 +159,7 @@ class Transformer:
                 return success, transformed_data
         else: # pylint: disable=useless-else-on-loop
             # exhaused all types and didn't return, so we failed :-(
-            self.errors.append(Error(path, data, schema))
+            self.errors.append(Error(path, data, schema, logging_level=LOGGER.level))
             return False, None
 
     def _transform_anyof(self, data, schema, path):
@@ -165,7 +170,7 @@ class Transformer:
                 return success, transformed_data
         else: # pylint: disable=useless-else-on-loop
             # exhaused all schemas and didn't return, so we failed :-(
-            self.errors.append(Error(path, data, schema))
+            self.errors.append(Error(path, data, schema, logging_level=LOGGER.level))
             return False, None
 
     def _transform_object(self, data, schema, path, pattern_properties):

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -69,10 +69,10 @@ class Error:
         else:
             msg = "not in schema"
         if self.logging_level >= logging.INFO:
-            f = "{}: data {}".format(path, msg)
+            output = "{}: data {}".format(path, msg)
         else:
-            f = "{}: {} {}".format(path, self.data, msg)
-        return f
+            output = "{}: {} {}".format(path, self.data, msg)
+        return output
 
 
 class Transformer:


### PR DESCRIPTION
# Description of change
Do not output raw data to logs when a SchemaMismatch error occurs in the transformer.

# Manual QA steps
 - Ran a tap which outputs a record that violates the JSON Schema. Observed the appropriate output 
 
# Risks
 - A little bit harder to diagnose a bug where a record violates its JSON Schema data type(s).
 
# Rollback steps
 - revert this branch

To observe the old behavior, modify [logging.conf](https://github.com/singer-io/singer-python/blob/master/singer/logging.conf#L11) to `DEBUG` and the output display the raw record.