### PR TITLE
Make logger more customizable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 
 from setuptools import setup, find_packages
-import subprocess
 
 setup(name="singer-python",
-      version='5.9.0',
+      version='5.10.0',
       description="Singer.io utility library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],
@@ -15,7 +14,7 @@ setup(name="singer-python",
           'simplejson==3.11.1',
           'python-dateutil>=2.6.0',
           'backoff==1.8.0',
-	  'ciso8601',
+          'ciso8601',
       ],
       extras_require={
           'dev': [

--- a/singer/__init__.py
+++ b/singer/__init__.py
@@ -10,16 +10,7 @@ from singer.utils import (
     should_sync_field,
 )
 
-from singer.logger import (
-    get_logger,
-    log_debug,
-    log_info,
-    log_warning,
-    log_error,
-    log_critical,
-    log_fatal,
-    log_exception,
-)
+from singer.logger import Logger
 
 from singer.metrics import (
     Counter,

--- a/singer/catalog.py
+++ b/singer/catalog.py
@@ -4,16 +4,16 @@ import sys
 
 from . import metadata as metadata_module
 from .bookmarks import get_currently_syncing
-from .logger import get_logger
+from .logger import Logger
 from .schema import Schema
 
-LOGGER = get_logger()
+LOGGER = Logger()
 
 
 def write_catalog(catalog):
     # If the catalog has no streams, log a warning
     if not catalog.streams:
-        LOGGER.warning("Catalog being written with no streams.")
+        LOGGER.log_warning("Catalog being written with no streams.")
 
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
 
@@ -150,7 +150,7 @@ class Catalog():
     def get_selected_streams(self, state):
         for stream in self._shuffle_streams(state):
             if not stream.is_selected():
-                LOGGER.info('Skipping stream: %s', stream.tap_stream_id)
+                LOGGER.log_info('Skipping stream: %s', stream.tap_stream_id)
                 continue
 
             yield stream

--- a/singer/logger.py
+++ b/singer/logger.py
@@ -12,11 +12,15 @@ class Logger:
         :param config_file_path: path to a custom logging file
         :param logger_name: custom name for logger
         """
-
-        # fallback to singer's logging.conf if no file is given
         if not config_file_path:
-            this_dir, _ = os.path.split(__file__)
-            config_file_path = os.path.join(this_dir, 'logging.conf')
+            # look for the path in the os environment
+            if os.environ.get('LOGGER_CONFIG_PATH'):
+                config_file_path = os.environ.get('LOGGER_CONFIG_PATH')
+
+            # fallback to singer's logging.conf
+            else:
+                this_dir, _ = os.path.split(__file__)
+                config_file_path = os.path.join(this_dir, 'logging.conf')
 
         # See
         # https://docs.python.org/3.5/library/logging.config.html#logging.config.fileConfig
@@ -54,3 +58,7 @@ class Logger:
 
     def get_level(self):
         return self.__logger.level
+
+    @property
+    def logger(self):
+        return self.__logger

--- a/singer/logger.py
+++ b/singer/logger.py
@@ -1,45 +1,56 @@
 import logging
 import logging.config
 import os
+from typing import Optional
 
 
-def get_logger():
-    """Return a Logger instance appropriate for using in a Tap or a Target."""
-    this_dir, _ = os.path.split(__file__)
-    path = os.path.join(this_dir, 'logging.conf')
-    # See
-    # https://docs.python.org/3.5/library/logging.config.html#logging.config.fileConfig
-    # for a discussion of why or why not to set disable_existing_loggers
-    # to False. The long and short of it is that if you don't set it to
-    # False it ruins external module's abilities to use the logging
-    # facility.
-    logging.config.fileConfig(path, disable_existing_loggers=False)
-    return logging.getLogger()
+class Logger(object):
 
+    def __init__(self, config_file_path: Optional[str] = None, logger_name: Optional[str] = None):
+        """
+        Creates a Logger instance appropriate for using in a Tap or a Target.
+        :param config_file_path: path to a custom logging file
+        :param logger_name: custom name for logger
+        """
 
-def log_debug(msg, *args, **kwargs):
-    get_logger().debug(msg, *args, **kwargs)
+        # fallback to singer's logging.conf if no file is given
+        if not config_file_path:
+            this_dir, _ = os.path.split(__file__)
+            config_file_path = os.path.join(this_dir, 'logging.conf')
 
+        # See
+        # https://docs.python.org/3.5/library/logging.config.html#logging.config.fileConfig
+        # for a discussion of why or why not to set disable_existing_loggers
+        # to False. The long and short of it is that if you don't set it to
+        # False it ruins external module's abilities to use the logging
+        # facility.
+        logging.config.fileConfig(config_file_path, disable_existing_loggers=False)
 
-def log_info(msg, *args, **kwargs):
-    get_logger().info(msg, *args, **kwargs)
+        # use current file name as logger name
+        logger_name = __name__ if not logger_name else logger_name
 
+        self.__logger = logging.getLogger(logger_name)
 
-def log_warning(msg, *args, **kwargs):
-    get_logger().warning(msg, *args, **kwargs)
+    def log_debug(self, msg, *args, **kwargs):
+        self.__logger.debug(msg, *args, **kwargs)
 
+    def log_info(self, msg, *args, **kwargs):
+        self.__logger.info(msg, *args, **kwargs)
 
-def log_error(msg, *args, **kwargs):
-    get_logger().error(msg, *args, **kwargs)
+    def log_warning(self, msg, *args, **kwargs):
+        self.__logger.warning(msg, *args, **kwargs)
 
+    def log_error(self, msg, *args, **kwargs):
+        self.__logger.error(msg, *args, **kwargs)
 
-def log_critical(msg, *args, **kwargs):
-    get_logger().critical(msg, *args, **kwargs)
+    def log_critical(self, msg, *args, **kwargs):
+        self.__logger.critical(msg, *args, **kwargs)
 
+    def log_fatal(self, msg, *args, **kwargs):
+        self.__logger.fatal(msg, *args, **kwargs)
 
-def log_fatal(msg, *args, **kwargs):
-    get_logger().fatal(msg, *args, **kwargs)
+    def log_exception(self, msg, *args, **kwargs):
+        self.__logger.exception(msg, *args, **kwargs)
 
-
-def log_exception(msg, *args, **kwargs):
-    get_logger().exception(msg, *args, **kwargs)
+    def get_level(self):
+        return self.__logger.level

--- a/singer/logger.py
+++ b/singer/logger.py
@@ -4,7 +4,7 @@ import os
 from typing import Optional
 
 
-class Logger(object):
+class Logger:
 
     def __init__(self, config_file_path: Optional[str] = None, logger_name: Optional[str] = None):
         """

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -5,8 +5,8 @@ import simplejson as json
 import ciso8601
 
 import singer.utils as u
-from .logger import get_logger
-LOGGER = get_logger()
+from .logger import Logger
+LOGGER = Logger()
 
 class Message():
     '''Base class for messages.'''
@@ -191,7 +191,7 @@ def parse_message(msg):
             try:
                 time_extracted = ciso8601.parse_datetime(time_extracted)
             except:
-                LOGGER.warning("unable to parse time_extracted with ciso8601 library")
+                LOGGER.log_warning("unable to parse time_extracted with ciso8601 library")
                 time_extracted = None
 
 

--- a/singer/metrics.py
+++ b/singer/metrics.py
@@ -44,10 +44,10 @@ import json
 import re
 import time
 from collections import namedtuple
-from singer.logger import get_logger
+from singer.logger import Logger
 
 DEFAULT_LOG_INTERVAL = 60
-
+LOGGER = Logger()
 
 class Status:
     '''Constants for status codes'''
@@ -84,7 +84,7 @@ def log(logger, point):
         'value': point.value,
         'tags': point.tags
     }
-    logger.info('METRIC: %s', json.dumps(result))
+    logger.log_info('METRIC: %s', json.dumps(result))
 
 
 class Counter():
@@ -118,7 +118,7 @@ class Counter():
         self.value = 0
         self.tags = tags if tags else {}
         self.log_interval = log_interval
-        self.logger = get_logger()
+        self.logger = Logger()
         self.last_log_time = time.time()
 
     def __enter__(self):
@@ -173,7 +173,7 @@ class Timer():  # pylint: disable=too-few-public-methods
     def __init__(self, metric, tags):
         self.metric = metric
         self.tags = tags if tags else {}
-        self.logger = get_logger()
+        self.logger = Logger()
         self.start_time = None
 
     def __enter__(self):
@@ -244,5 +244,5 @@ def parse(line):
                 value=raw.get('value'),
                 tags=raw.get('tags'))
         except Exception as exc:  # pylint: disable=broad-except
-            get_logger().warning('Error parsing metric: %s', exc)
+            LOGGER.log_warning('Error parsing metric: %s', exc)
     return None

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -48,12 +48,14 @@ class SchemaMismatch(Exception):
 
         super(SchemaMismatch, self).__init__(msg)
 
+
 class SchemaKey:
     ref = "$ref"
     items = "items"
     properties = "properties"
     pattern_properties = "patternProperties"
     any_of = 'anyOf'
+
 
 class Error:
     def __init__(self, path, data, schema=None, logging_level=logging.INFO):
@@ -90,17 +92,17 @@ class Transformer:
     def log_warning(self):
         if self.filtered:
             LOGGER.log_debug("Filtered %s paths during transforms "
-                         "as they were unsupported or not selected:\n\t%s",
-                         len(self.filtered),
-                         "\n\t".join(sorted(self.filtered)))
+                             "as they were unsupported or not selected:\n\t%s",
+                             len(self.filtered),
+                             "\n\t".join(sorted(self.filtered)))
             # Output list format to parse for reporting
             LOGGER.log_debug("Filtered paths list: %s",
-                         sorted(self.filtered))
+                             sorted(self.filtered))
 
         if self.removed:
             LOGGER.log_debug("Removed %s paths during transforms:\n\t%s",
-                         len(self.removed),
-                         "\n\t".join(sorted(self.removed)))
+                             len(self.removed),
+                             "\n\t".join(sorted(self.removed)))
             # Output list format to parse for reporting
             LOGGER.log_debug("Removed paths list: %s", sorted(self.removed))
 
@@ -161,7 +163,7 @@ class Transformer:
             success, transformed_data = self._transform(data, typ, schema, path)
             if success:
                 return success, transformed_data
-        else: # pylint: disable=useless-else-on-loop
+        else:  # pylint: disable=useless-else-on-loop
             # exhaused all types and didn't return, so we failed :-(
             self.errors.append(Error(path, data, schema, logging_level=LOGGER.get_level()))
             return False, None
@@ -172,7 +174,7 @@ class Transformer:
             success, transformed_data = self.transform_recur(data, subschema, path)
             if success:
                 return success, transformed_data
-        else: # pylint: disable=useless-else-on-loop
+        else:  # pylint: disable=useless-else-on-loop
             # exhaused all schemas and didn't return, so we failed :-(
             self.errors.append(Error(path, data, schema, logging_level=LOGGER.get_level()))
             return False, None
@@ -227,7 +229,7 @@ class Transformer:
 
     def _transform_datetime(self, value):
         if value is None or value == "":
-            return None # Short circuit in the case of null or empty string
+            return None  # Short circuit in the case of null or empty string
 
         if self.integer_datetime_fmt not in VALID_DATETIME_FORMATS:
             raise Exception("Invalid integer datetime parsing option")
@@ -332,9 +334,11 @@ def transform(data, schema, integer_datetime_fmt=NO_INTEGER_DATETIME_PARSING,
     transformer = Transformer(integer_datetime_fmt, pre_hook)
     return transformer.transform(data, schema, metadata=metadata)
 
+
 def _transform_datetime(value, integer_datetime_fmt=NO_INTEGER_DATETIME_PARSING):
     transformer = Transformer(integer_datetime_fmt)
     return transformer._transform_datetime(value)
+
 
 def resolve_schema_references(schema, refs=None):
     '''Resolves and replaces json-schema $refs with the appropriate dict.
@@ -355,6 +359,7 @@ def resolve_schema_references(schema, refs=None):
     '''
     refs = refs or {}
     return _resolve_schema_references(schema, RefResolver("", schema, store=refs))
+
 
 def _resolve_schema_references(schema, resolver):
     if SchemaKey.ref in schema:

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -4,10 +4,10 @@ import re
 from jsonschema import RefResolver
 
 import singer.metadata
-from singer.logger import get_logger
+from singer.logger import Logger
 from singer.utils import (strftime, strptime_to_utc)
 
-LOGGER = get_logger()
+LOGGER = Logger()
 
 NO_INTEGER_DATETIME_PARSING = "no-integer-datetime-parsing"
 UNIX_SECONDS_INTEGER_DATETIME_PARSING = "unix-seconds-integer-datetime-parsing"
@@ -24,7 +24,7 @@ def string_to_datetime(value):
     try:
         return strftime(strptime_to_utc(value))
     except Exception as ex:
-        LOGGER.warning("%s, (%s)", ex, value)
+        LOGGER.log_warning("%s, (%s)", ex, value)
         return None
 
 
@@ -89,20 +89,20 @@ class Transformer:
 
     def log_warning(self):
         if self.filtered:
-            LOGGER.debug("Filtered %s paths during transforms "
+            LOGGER.log_debug("Filtered %s paths during transforms "
                          "as they were unsupported or not selected:\n\t%s",
                          len(self.filtered),
                          "\n\t".join(sorted(self.filtered)))
             # Output list format to parse for reporting
-            LOGGER.debug("Filtered paths list: %s",
+            LOGGER.log_debug("Filtered paths list: %s",
                          sorted(self.filtered))
 
         if self.removed:
-            LOGGER.debug("Removed %s paths during transforms:\n\t%s",
+            LOGGER.log_debug("Removed %s paths during transforms:\n\t%s",
                          len(self.removed),
                          "\n\t".join(sorted(self.removed)))
             # Output list format to parse for reporting
-            LOGGER.debug("Removed paths list: %s", sorted(self.removed))
+            LOGGER.log_debug("Removed paths list: %s", sorted(self.removed))
 
     def __enter__(self):
         return self
@@ -163,7 +163,7 @@ class Transformer:
                 return success, transformed_data
         else: # pylint: disable=useless-else-on-loop
             # exhaused all types and didn't return, so we failed :-(
-            self.errors.append(Error(path, data, schema, logging_level=LOGGER.level))
+            self.errors.append(Error(path, data, schema, logging_level=LOGGER.get_level()))
             return False, None
 
     def _transform_anyof(self, data, schema, path):
@@ -174,7 +174,7 @@ class Transformer:
                 return success, transformed_data
         else: # pylint: disable=useless-else-on-loop
             # exhaused all schemas and didn't return, so we failed :-(
-            self.errors.append(Error(path, data, schema, logging_level=LOGGER.level))
+            self.errors.append(Error(path, data, schema, logging_level=LOGGER.get_level()))
             return False, None
 
     def _transform_object(self, data, schema, path, pattern_properties):

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -228,7 +228,7 @@ def handle_top_exception(logger):
             try:
                 return fnc(*args, **kwargs)
             except Exception as exc:
-                logger.critical(exc)
+                logger.log_critical(exc)
                 raise
         return wrapped
     return decorator

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -228,7 +228,7 @@ def handle_top_exception(logger):
             try:
                 return fnc(*args, **kwargs)
             except Exception as exc:
-                logger.log_critical(exc)
+                logger.critical(exc)
                 raise
         return wrapped
     return decorator


### PR DESCRIPTION
# Description of change
Due to the need to have control over how logs are displayed, e.g showing timestamps, logger name ...etc. I have made these changes so that the taps and targets can provide custom `logging.conf` file and a logger name. 

# Manual QA steps
 - Run a tap using these changes and provide custom `logging.conf` file, then observe the logs.
Example of logging file:
  ```
[loggers]
keys=root

[handlers] 
keys=stderr

[formatters]
keys=child

[logger_root]
level=INFO
handlers=stderr
formatter=child
propagate=0

[handler_stderr]
class=StreamHandler
formatter=child
args=(sys.stderr,)

[formatter_child]
class=logging.Formatter
format=%(asctime)s %(name)s %(levelname)s: %(message)s
datefmt=%Y-%m-%d %H:%M:%S
```
 
# Risks
 - None, it is a breaking change though.
 
# Rollback steps
 - revert this branch
