### PR TITLE
Add support for custom decimal string formatter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="singer-python",
-      version='5.8.1',
+      version='5.9.0',
       description="Singer.io utility library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -251,6 +251,8 @@ class Transformer:
         if typ == "null":
             if data is None or data == "":
                 return True, None
+            elif isinstance(data, decimal.Decimal) and data.is_nan():
+                return True, None
             else:
                 return False, None
 
@@ -260,7 +262,7 @@ class Transformer:
                 return False, None
 
             return True, data
-        elif schema.get("format") == "decimal":
+        elif schema.get("format") == "singer.decimal":
             if data is None:
                 return False, None
 

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -1,4 +1,5 @@
 import datetime
+import decimal
 import logging
 import re
 from jsonschema import RefResolver
@@ -263,7 +264,7 @@ class Transformer:
             if data is None:
                 return False, None
 
-            if type(data) in (str, float, int):
+            if isinstance(data, (str, float, int)):
                 try:
                     return True, str(decimal.Decimal(str(data)).normalize())
                 except:

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -284,7 +284,7 @@ class Transformer:
             elif isinstance(data, decimal.Decimal):
                 try:
                     if data.is_snan():
-                        return True, str(data)
+                        return True, 'NaN'
                     else:
                         return True, str(data.normalize())
                 except:

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -265,7 +265,7 @@ class Transformer:
 
             if type(data) in (str, float, int):
                 try:
-                    return True, decimal.Decimal(str(data)).normalize()
+                    return True, str(decimal.Decimal(str(data)).normalize())
                 except:
                     return False, None
             elif isinstance(data, decimal.Decimal):
@@ -273,9 +273,9 @@ class Transformer:
                 if data.is_nan() or data.is_snan() or data.is_qnan():
                     return True, None
                 else:
-                    return True, data.normalize()
+                    return True, str(data.normalize())
 
-            return success, result
+            return False, None
         elif typ == "object":
             # Objects do not necessarily specify properties
             return self._transform_object(data,

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -259,7 +259,23 @@ class Transformer:
                 return False, None
 
             return True, data
+        elif schema.get("format") == "decimal":
+            if data is None:
+                return False, None
 
+            if type(data) in (str, float, int):
+                try:
+                    return True, decimal.Decimal(str(data)).normalize()
+                except:
+                    return False, None
+            elif isinstance(data, decimal.Decimal):
+                # NB: This treats all NaN values as "null"
+                if data.is_nan() or data.is_snan() or data.is_qnan():
+                    return True, None
+                else:
+                    return True, data.normalize()
+
+            return success, result
         elif typ == "object":
             # Objects do not necessarily specify properties
             return self._transform_object(data,

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -251,8 +251,6 @@ class Transformer:
         if typ == "null":
             if data is None or data == "":
                 return True, None
-            elif isinstance(data, decimal.Decimal) and data.is_nan():
-                return True, None
             else:
                 return False, None
 
@@ -272,11 +270,13 @@ class Transformer:
                 except:
                     return False, None
             elif isinstance(data, decimal.Decimal):
-                # NB: This treats all NaN values as "null"
-                if data.is_nan() or data.is_snan() or data.is_qnan():
-                    return True, None
-                else:
-                    return True, str(data.normalize())
+                try:
+                    if data.is_snan():
+                        return True, str(data)
+                    else:
+                        return True, str(data.normalize())
+                except:
+                    return False, None
 
             return False, None
         elif typ == "object":

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -268,7 +268,7 @@ class TestTransform(unittest.TestCase):
         self.assertEquals(negative_inf, transform(negative_inf, schema))
         self.assertEquals({'percentage': '1.4142135623730951'}, transform(root2, schema))
         self.assertEquals({'percentage': 'NaN'}, transform(nan, schema))
-        self.assertEquals({'percentage': 'sNaN'}, transform(snan, schema))
+        self.assertEquals({'percentage': 'NaN'}, transform(snan, schema))
 
 
         str1 = {'percentage':'0.1'}

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,5 +1,4 @@
 import unittest
-import math
 import decimal
 from singer import transform
 from singer.transform import *
@@ -51,7 +50,6 @@ class TestTransform(unittest.TestCase):
         self.assertEqual(None, transform(None, {'type': [ 'string', 'null']}))
         self.assertEqual(None, transform('', {'type': ['null']}))
         self.assertEqual(None, transform(None, {'type': ['null']}))
-        self.assertEqual(None, transform(decimal.Decimal('NaN'), {'type': ['null']}))
 
     def test_datetime_transform(self):
         schema = {"type": "string", "format": "date-time"}
@@ -257,21 +255,21 @@ class TestTransform(unittest.TestCase):
 
     def test_decimal_types_transform(self):
         schema =  {"type": "object",
-                   "properties": {"percentage": {"type": ["null", "string"],
+                   "properties": {"percentage": {"type": ["string"],
                                                  "format": "singer.decimal"}}}
 
         inf = {'percentage': 'Infinity'}
         negative_inf = {'percentage': '-Infinity'}
-        root2  = {'percentage': math.sqrt(2)}
+        root2  = {'percentage': 1.4142135623730951}
         nan = {'percentage': decimal.Decimal('NaN')}
         snan = {'percentage': decimal.Decimal('sNaN')}
-        null = {'percentage': None}
+
         self.assertEquals(inf, transform(inf, schema))
         self.assertEquals(negative_inf, transform(negative_inf, schema))
-        self.assertEquals({'percentage': str(math.sqrt(2))}, transform(root2, schema))
-        self.assertEquals({'percentage': None}, transform(nan, schema))
-        self.assertEquals({'percentage': None}, transform(snan, schema))
-        self.assertEquals({'percentage':None}, transform(null, schema))
+        self.assertEquals({'percentage': '1.4142135623730951'}, transform(root2, schema))
+        self.assertEquals({'percentage': 'NaN'}, transform(nan, schema))
+        self.assertEquals({'percentage': 'sNaN'}, transform(snan, schema))
+
 
         str1 = {'percentage':'0.1'}
         str2 = {'percentage': '0.0000000000001'}
@@ -313,6 +311,9 @@ class TestTransform(unittest.TestCase):
         with self.assertRaises(SchemaMismatch):
             transform(bad1, schema)
 
+        badnull = {'percentage': None}
+        with self.assertRaises(SchemaMismatch):
+            self.assertEquals({'percentage':None}, transform(badnull, schema))
 
 class TestTransformsWithMetadata(unittest.TestCase):
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,4 +1,6 @@
 import unittest
+import math
+import decimal
 from singer import transform
 from singer.transform import *
 
@@ -49,6 +51,7 @@ class TestTransform(unittest.TestCase):
         self.assertEqual(None, transform(None, {'type': [ 'string', 'null']}))
         self.assertEqual(None, transform('', {'type': ['null']}))
         self.assertEqual(None, transform(None, {'type': ['null']}))
+        self.assertEqual(None, transform(decimal.Decimal('NaN'), {'type': ['null']}))
 
     def test_datetime_transform(self):
         schema = {"type": "string", "format": "date-time"}
@@ -251,6 +254,65 @@ class TestTransform(unittest.TestCase):
         self.assertDictEqual(none_data, transform(none_data, schema))
         empty_data = {'addrs': {}}
         self.assertDictEqual(empty_data, transform(empty_data, schema))
+
+    def test_decimal_types_transform(self):
+        schema =  {"type": "object",
+                   "properties": {"percentage": {"type": ["null", "string"],
+                                                 "format": "singer.decimal"}}}
+
+        inf = {'percentage': 'Infinity'}
+        negative_inf = {'percentage': '-Infinity'}
+        root2  = {'percentage': math.sqrt(2)}
+        nan = {'percentage': decimal.Decimal('NaN')}
+        snan = {'percentage': decimal.Decimal('sNaN')}
+        null = {'percentage': None}
+        self.assertEquals(inf, transform(inf, schema))
+        self.assertEquals(negative_inf, transform(negative_inf, schema))
+        self.assertEquals({'percentage': str(math.sqrt(2))}, transform(root2, schema))
+        self.assertEquals({'percentage': None}, transform(nan, schema))
+        self.assertEquals({'percentage': None}, transform(snan, schema))
+        self.assertEquals({'percentage':None}, transform(null, schema))
+
+        str1 = {'percentage':'0.1'}
+        str2 = {'percentage': '0.0000000000001'}
+        str3 = {'percentage': '1E+13'}
+        str4 = {'percentage': '100'}
+        str5 = {'percentage': '-100'}
+        self.assertEquals(str1, transform(str1, schema))
+        self.assertEquals({'percentage': '1E-13'}, transform(str2, schema))
+        self.assertEquals({'percentage': '1E+13'}, transform(str3, schema))
+        self.assertEquals({'percentage': '1E+2'}, transform(str4, schema))
+        self.assertEquals({'percentage': '-1E+2'}, transform(str5, schema))
+
+        float1 = {'percentage': 12.0000000000000000000000000001234556}
+        float2 = {'percentage': 0.0123}
+        float3 = {'percentage': 100.0123}
+        float4 = {'percentage': -100.0123}
+        self.assertEquals({'percentage':'12'}, transform(float1, schema))
+        self.assertEquals({'percentage':'0.0123'}, transform(float2, schema))
+        self.assertEquals({'percentage':'100.0123'}, transform(float3, schema))
+        self.assertEquals({'percentage':'-100.0123'}, transform(float4, schema))
+
+        int1 = {'percentage': 123}
+        int2 = {'percentage': 0}
+        int3 = {'percentage': -1000}
+        self.assertEquals({'percentage':'123'}, transform(int1, schema))
+        self.assertEquals({'percentage':'0'}, transform(int2, schema))
+        self.assertEquals({'percentage':'-1E+3'}, transform(int3, schema))
+
+        dec1 = {'percentage': decimal.Decimal('1.1010101')}
+        dec2 = {'percentage': decimal.Decimal('.111111111111111111111111')}
+        dec3 = {'percentage': decimal.Decimal('-.111111111111111111111111')}
+        dec4 = {'percentage': decimal.Decimal('100')}
+        self.assertEquals({'percentage':'1.1010101'}, transform(dec1, schema))
+        self.assertEquals({'percentage':'0.111111111111111111111111'}, transform(dec2, schema))
+        self.assertEquals({'percentage':'-0.111111111111111111111111'}, transform(dec3, schema))
+        self.assertEquals({'percentage':'1E+2'}, transform(dec4, schema))
+
+        bad1 = {'percentage': 'fsdkjl'}
+        with self.assertRaises(SchemaMismatch):
+            transform(bad1, schema)
+
 
 class TestTransformsWithMetadata(unittest.TestCase):
 


### PR DESCRIPTION
# Description of change
This PR introduces a new concept: A Singer custom string format type that specifies a decimal value.

The reasoning behind this is to maintain decimal precision throughout ELT pipelines by converting to and from JSON strings and parsing with `decimal.Decimal` (in Python).

# Manual QA steps
 - None, will write automated unittests to exercise this function.
 
# Risks
 - Low, this is an additive feature.
 
# Rollback steps
 - revert this branch
