### PR TITLE
Update jsonschema version range.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name="singer-python",
       url="http://singer.io",
       install_requires=[
           'pytz==2018.4',
-          'jsonschema==2.6.0',
+          'jsonschema>=2.6.0,<=3.2.0',
           'simplejson==3.11.1',
           'python-dateutil>=2.6.0',
           'backoff==1.8.0',


### PR DESCRIPTION
# Description of change
---
This includes the same changes as in https://github.com/singer-io/singer-python/pull/123, however, I signed the contribution agreement. This dependency issue precludes the use of any singer taps/targets with [Google Cloud Composer][cloud_composer] since the builds fail with `jsonschema` version incompatibilities. This change will also avoid confusion for those viewing the Stitch Medium post [Superching ETL with Airflow and Singer][stitch]. For those hosting Airflow themselves, @feluelle further describes the motivations for the change:

"Airflow 1.10.7 added the jsonschema dependency to support serializing/deserialising data in its meta database.
Because singer-python pins the jsonschema version to 2.6.0, it can no longer be used in Airflows newer versions in the same Python venv.

This change would allow users to use singer-python in a newer Airflow Environment."

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

[cloud_composer]: https://cloud.google.com/composer
[stitch]: https://www.stitchdata.com/blog/supercharging-etl-with-airflow-and-singer/