### PR TITLE
Filter nested properties based on metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,5 @@ install: check_prereqs
 	python3 -m pip install -e '.[dev]'
 
 test: install
-	pylint singer -d missing-docstring,broad-except,bare-except,too-many-return-statements,too-many-branches,too-many-arguments,no-else-return,too-few-public-methods,fixme,protected-access
+	pylint singer --extension-pkg-whitelist=ciso8601 -d missing-docstring,broad-except,bare-except,too-many-return-statements,too-many-branches,too-many-arguments,no-else-return,too-few-public-methods,fixme,protected-access
 	nosetests --with-doctest -v

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -140,7 +140,7 @@ class Transformer:
 
         if isinstance(data, list) and metadata:
             breadcrumb = parent + ('items',)
-            data = [self.filter_data_by_metadata(d, metadata, parent + ('items', )) for d in data]
+            data = [self.filter_data_by_metadata(d, metadata, breadcrumb) for d in data]
 
         return data
 

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -56,7 +56,7 @@ class SchemaMismatch(Exception):
             msg = "Errors during transform\n\t{}".format("\n\t".join(estrs))
             msg += "\n\n\nErrors during transform: [{}]".format(", ".join(estrs))
 
-        super(SchemaMismatch, self).__init__(msg)
+        super().__init__(msg)
 
 class SchemaKey:
     ref = "$ref"

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -295,6 +295,49 @@ class TestTransformsWithMetadata(unittest.TestCase):
         dict_value = {"name": "chicken"}
         self.assertEqual({}, transform(dict_value, schema, NO_INTEGER_DATETIME_PARSING, metadata=metadata))
 
+    def test_drops_nested_object_fields_which_are_unselected(self):
+        schema = {"type": "object",
+                   "properties": {"addr": {"type": "object",
+                                            "properties": {"addr1": {"type": "string"},
+                                                           "city": {"type": "string"},
+                                                           "state": {"type": "string"},
+                                                           'amount': {'type': 'integer'}}}}}
+        metadata = {
+            ('properties','addr'): {"selected": True},
+            ('properties','addr', 'properties','amount'): {"selected": False}
+        }
+        data = {'addr':
+            {'addr1': 'address_1', 'city': 'city_1', 'state': 'state_1', 'amount': '123'}
+        }
+        expected = {'addr':
+            {'addr1': 'address_1', 'city': 'city_1', 'state': 'state_1'},
+        }
+        self.assertDictEqual(expected, transform(data, schema, NO_INTEGER_DATETIME_PARSING, metadata=metadata))
+
+    def test_drops_nested_array_fields_which_are_unselected(self):
+        schema = {"type": "object",
+                   "properties": {"addrs": {"type": "array",
+                                            "items": {"type": "object",
+                                                      "properties": {"addr1": {"type": "string"},
+                                                                     "city": {"type": "string"},
+                                                                     "state": {"type": "string"},
+                                                                     'amount': {'type': 'integer'}}}}}}
+        metadata = {
+            ('properties','addrs'): {"selected": True},
+            ('properties','addrs','items','properties','amount'): {"selected": False}
+        }
+        data = {'addrs': [
+                {'addr1': 'address_1', 'city': 'city_1', 'state': 'state_1', 'amount': '123'},
+                {'addr1': 'address_2', 'city': 'city_2', 'state': 'state_2', 'amount': '456'}
+            ]
+        }
+        expected = {'addrs': [
+                {'addr1': 'address_1', 'city': 'city_1', 'state': 'state_1'},
+                {'addr1': 'address_2', 'city': 'city_2', 'state': 'state_2'}
+            ]
+        }
+        self.assertDictEqual(expected, transform(data, schema, NO_INTEGER_DATETIME_PARSING, metadata=metadata))
+
 class TestResolveSchemaReferences(unittest.TestCase):
     def test_internal_refs_resolve(self):
         schema =  {"type": "object",


### PR DESCRIPTION
# Description of change
This is an extension of PR #94. I have added two tests, one which tests that nested fields in an object are filtered and one which tests that nested fields in an array of objects are filtered.

# Manual QA steps
 - Wrote new tests which pass
 
# Risks
 - Should not be any breaking changes as all previous tests pass unaltered.
 
# Rollback steps
 - revert this branch
