### PR TITLE
Fix tests for get_standard_metadata

### DIFF
--- a/singer/metadata.py
+++ b/singer/metadata.py
@@ -24,7 +24,7 @@ def get(compiled_metadata, breadcrumb, k):
 
 def get_standard_metadata(schema=None, schema_name=None, key_properties=None,
                           valid_replication_keys=None, replication_method=None):
-    mdata = {(): {}}
+    mdata = {}
 
     if key_properties is not None:
         mdata = write(mdata, (), 'table-key-properties', key_properties)

--- a/singer/metadata.py
+++ b/singer/metadata.py
@@ -24,7 +24,7 @@ def get(compiled_metadata, breadcrumb, k):
 
 def get_standard_metadata(schema=None, schema_name=None, key_properties=None,
                           valid_replication_keys=None, replication_method=None):
-    mdata = {}
+    mdata = {(): {}}
 
     if key_properties is not None:
         mdata = write(mdata, (), 'table-key-properties', key_properties)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -71,7 +71,7 @@ class TestStandardMetadata(unittest.TestCase):
         # dictionary of parameters for `get_standard_metadata()` and the
         # second element is the expected metadata
         test_variables = [
-            (
+            ( # test_number=0
                 {
                     'schema': test_schema,
                     'schema_name': tap_stream_id,
@@ -84,7 +84,7 @@ class TestStandardMetadata(unittest.TestCase):
                     {'schema-name': tap_stream_id,}
                 )
             ),
-            (
+            ( # test_number=1
                 {
                     'schema': test_schema,
                     'schema_name': tap_stream_id,
@@ -98,7 +98,7 @@ class TestStandardMetadata(unittest.TestCase):
                      'schema-name':tap_stream_id}
                 )
             ),
-            (
+            ( # test_number=2
                 {
                     'schema': test_schema,
                     'schema_name': tap_stream_id,
@@ -112,7 +112,7 @@ class TestStandardMetadata(unittest.TestCase):
                      'schema-name':tap_stream_id}
                 )
             ),
-            (
+            ( # test_number=3
                 {
                     'schema': test_schema,
                     'schema_name': tap_stream_id,
@@ -127,7 +127,7 @@ class TestStandardMetadata(unittest.TestCase):
                      'schema-name':tap_stream_id}
                 )
             ),
-            (
+            ( # test_number=4
                 {
                     'schema': test_schema,
                     'schema_name': tap_stream_id,
@@ -142,7 +142,7 @@ class TestStandardMetadata(unittest.TestCase):
                     has_pk=True
                 )
             ),
-            (
+            ( # test_number=5
                 {
                     'schema': test_schema,
                     'schema_name': tap_stream_id,
@@ -158,7 +158,7 @@ class TestStandardMetadata(unittest.TestCase):
                     has_pk=True
                 )
             ),
-            (
+            ( # test_number=6
                 {
                     'schema': test_schema,
                     'schema_name': tap_stream_id,
@@ -174,7 +174,7 @@ class TestStandardMetadata(unittest.TestCase):
                     has_pk=True
                 )
             ),
-            (
+            ( # test_number=7
                 {
                     'schema': test_schema,
                     'schema_name': tap_stream_id,
@@ -191,7 +191,7 @@ class TestStandardMetadata(unittest.TestCase):
                     has_pk=True
                 )
             ),
-            (
+            ( # test_number=8
                 {
                     'schema': None,
                     'key_properties': None,
@@ -205,7 +205,7 @@ class TestStandardMetadata(unittest.TestCase):
                     }
                 ]
             ),
-            (
+            ( # test_number=9
                 {
                     'schema': None,
                     'key_properties': None,
@@ -221,7 +221,7 @@ class TestStandardMetadata(unittest.TestCase):
                     }
                 ]
             ),
-            (
+            ( # test_number=10
                 {
                     'schema': None,
                     'key_properties': None,
@@ -237,7 +237,7 @@ class TestStandardMetadata(unittest.TestCase):
                     }
                 ]
             ),
-            (
+            ( # test_number=11
                 {
                     'schema': None,
                     'key_properties': None,
@@ -254,7 +254,7 @@ class TestStandardMetadata(unittest.TestCase):
                     }
                 ]
             ),
-            (
+            ( # test_number=12
                 {
                     'schema': None,
                     'key_properties': test_kp,
@@ -270,7 +270,7 @@ class TestStandardMetadata(unittest.TestCase):
                     }
                 ]
             ),
-            (
+            ( # test_number=13
                 {
                     'schema': None,
                     'key_properties': test_kp,
@@ -287,7 +287,7 @@ class TestStandardMetadata(unittest.TestCase):
                     }
                 ]
             ),
-            (
+            ( # test_number=15
                 {
                     'schema': None,
                     'key_properties': test_kp,

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -33,9 +33,8 @@ def make_expected_metadata(base_obj, dict_of_extras, test_kp=False):
 
 class TestStandardMetadata(unittest.TestCase):
 
-    #maxDiff = None
-
     def test_standard_metadata(self):
+        self.maxDiff = None
 
         # Some contants shared by a number of expected metadata objects
         tap_stream_id = 'employees'

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -287,6 +287,23 @@ class TestStandardMetadata(unittest.TestCase):
                     }
                 ]
             ),
+            ( # test_number=14
+                {
+                    'schema': None,
+                    'key_properties': test_kp,
+                    'replication_method': test_rm,
+                    'valid_replication_keys': None
+                },
+                [
+                    {
+                        'metadata': {
+                            'table-key-properties': ['id'],
+                            'forced-replication-method': 'INCREMENTAL',
+                        },
+                        'breadcrumb': []
+                    }
+                ]
+            ),
             ( # test_number=15
                 {
                     'schema': None,

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -308,14 +308,16 @@ class TestStandardMetadata(unittest.TestCase):
             )
         ]
 
-        for var in test_variables:
-            function_params = var[0]
-            expected_metadata = var[1]
+        for i, var in enumerate(test_variables):
+            with self.subTest(test_number=i):
+                function_params = var[0]
+                expected_metadata = var[1]
 
-            test_value = get_standard_metadata(**function_params)
+                test_value = get_standard_metadata(**function_params)
 
-            for obj in expected_metadata:
-                self.assertIn(obj, test_value)
+                expected_value = to_map(expected_metadata)
+                actual_value = to_map(test_value)
+                self.assertDictEqual(expected_value, actual_value)
 
         # Test one function call where the parameters are not splat in
         test_value = get_standard_metadata(test_schema,
@@ -330,8 +332,10 @@ class TestStandardMetadata(unittest.TestCase):
                                                     'valid-replication-keys': ['id','created'],
                                                     'schema-name':tap_stream_id},
                                                     test_kp=True)
-        for obj in expected_metadata:
-            self.assertIn(obj, test_value)
+        self.assertDictEqual(
+            to_map(expected_metadata),
+            to_map(test_value)
+        )
 
     def test_empty_key_properties_are_written(self):
         mdata = get_standard_metadata(key_properties=[])

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,6 +1,6 @@
 from pprint import pprint
 import unittest
-from singer.metadata import get_standard_metadata
+from singer.metadata import get_standard_metadata, to_map
 
 def make_expected_metadata(base_obj, dict_of_extras, test_kp=False):
     metadata_value = {**base_obj}

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -198,12 +198,7 @@ class TestStandardMetadata(unittest.TestCase):
                     'replication_method': None,
                     'valid_replication_keys': None
                 },
-                [
-                    {
-                        'metadata': {},
-                        'breadcrumb': ()
-                    }
-                ]
+                []
             ),
             ( # test_number=9
                 {

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,7 +2,7 @@ from pprint import pprint
 import unittest
 from singer.metadata import get_standard_metadata, to_map
 
-def make_expected_metadata(base_obj, dict_of_extras, test_kp=False):
+def make_expected_metadata(base_obj, dict_of_extras, has_pk=False):
     metadata_value = {**base_obj}
     metadata_value.update(dict_of_extras)
 
@@ -13,7 +13,7 @@ def make_expected_metadata(base_obj, dict_of_extras, test_kp=False):
         },
         {
             'metadata': {
-                'inclusion': 'available' if test_kp is False else 'automatic',
+                'inclusion': 'automatic' if has_pk else 'available',
             },
             'breadcrumb': ('properties', 'id')
         },
@@ -139,7 +139,7 @@ class TestStandardMetadata(unittest.TestCase):
                     schema_present_base_obj,
                     {'table-key-properties': ['id'],
                      'schema-name':tap_stream_id},
-                    test_kp=True
+                    has_pk=True
                 )
             ),
             (
@@ -151,12 +151,11 @@ class TestStandardMetadata(unittest.TestCase):
                     'valid_replication_keys': test_rk
                 },
                 make_expected_metadata(
-
                     schema_present_base_obj,
                     {'table-key-properties': ['id'],
                      'valid-replication-keys': ['id','created'],
                      'schema-name':tap_stream_id},
-                    test_kp=True
+                    has_pk=True
                 )
             ),
             (
@@ -172,7 +171,7 @@ class TestStandardMetadata(unittest.TestCase):
                     {'table-key-properties': ['id'],
                      'forced-replication-method': 'INCREMENTAL',
                      'schema-name':tap_stream_id},
-                    test_kp=True
+                    has_pk=True
                 )
             ),
             (
@@ -189,7 +188,7 @@ class TestStandardMetadata(unittest.TestCase):
                      'forced-replication-method': 'INCREMENTAL',
                      'valid-replication-keys': ['id','created'],
                      'schema-name':tap_stream_id},
-                    test_kp=True
+                    has_pk=True
                 )
             ),
             (
@@ -331,7 +330,7 @@ class TestStandardMetadata(unittest.TestCase):
                                                     'forced-replication-method': 'INCREMENTAL',
                                                     'valid-replication-keys': ['id','created'],
                                                     'schema-name':tap_stream_id},
-                                                    test_kp=True)
+                                                   has_pk=True)
         self.assertDictEqual(
             to_map(expected_metadata),
             to_map(test_value)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,7 +2,7 @@ from pprint import pprint
 import unittest
 from singer.metadata import get_standard_metadata
 
-def make_expected_metadata(base_obj, dict_of_extras):
+def make_expected_metadata(base_obj, dict_of_extras, test_kp=False):
     metadata_value = {**base_obj}
     metadata_value.update(dict_of_extras)
 
@@ -13,7 +13,7 @@ def make_expected_metadata(base_obj, dict_of_extras):
         },
         {
             'metadata': {
-                'inclusion': 'available',
+                'inclusion': 'available' if test_kp is False else 'automatic',
             },
             'breadcrumb': ('properties', 'id')
         },
@@ -44,7 +44,7 @@ class TestStandardMetadata(unittest.TestCase):
         test_rk = ['id', 'created']
         metadata_kp = {'table-key-properties': ['id']}
         metadata_rm = {'forced-replication-method': 'INCREMENTAL'}
-        metadata_rk = {'valid_replication_keys': ['id','created']}
+        metadata_rk = {'valid-replication-keys': ['id','created']}
         schema_present_base_obj = {'inclusion': 'available'}
         test_schema = {
             'type': ['null', 'object'],
@@ -84,7 +84,7 @@ class TestStandardMetadata(unittest.TestCase):
                 },
                 make_expected_metadata(
                     schema_present_base_obj,
-                    {'valid_replication_keys': ['id','created'],
+                    {'valid-replication-keys': ['id','created'],
                      'schema-name':tap_stream_id}
                 )
             ),
@@ -112,7 +112,7 @@ class TestStandardMetadata(unittest.TestCase):
                 },
                 make_expected_metadata(
                     schema_present_base_obj,
-                    {'valid_replication_keys': ['id','created'],
+                    {'valid-replication-keys': ['id','created'],
                      'forced-replication-method': 'INCREMENTAL',
                      'schema-name':tap_stream_id}
                 )
@@ -128,7 +128,8 @@ class TestStandardMetadata(unittest.TestCase):
                 make_expected_metadata(
                     schema_present_base_obj,
                     {'table-key-properties': ['id'],
-                     'schema-name':tap_stream_id}
+                     'schema-name':tap_stream_id},
+                    test_kp=True
                 )
             ),
             (
@@ -143,8 +144,9 @@ class TestStandardMetadata(unittest.TestCase):
 
                     schema_present_base_obj,
                     {'table-key-properties': ['id'],
-                     'valid_replication_keys': ['id','created'],
-                     'schema-name':tap_stream_id}
+                     'valid-replication-keys': ['id','created'],
+                     'schema-name':tap_stream_id},
+                    test_kp=True
                 )
             ),
             (
@@ -159,7 +161,8 @@ class TestStandardMetadata(unittest.TestCase):
                     schema_present_base_obj,
                     {'table-key-properties': ['id'],
                      'forced-replication-method': 'INCREMENTAL',
-                     'schema-name':tap_stream_id}
+                     'schema-name':tap_stream_id},
+                    test_kp=True
                 )
             ),
             (
@@ -174,8 +177,9 @@ class TestStandardMetadata(unittest.TestCase):
                     schema_present_base_obj,
                     {'table-key-properties': ['id'],
                      'forced-replication-method': 'INCREMENTAL',
-                     'valid_replication_keys': ['id','created'],
-                     'schema-name':tap_stream_id}
+                     'valid-replication-keys': ['id','created'],
+                     'schema-name':tap_stream_id},
+                    test_kp=True
                 )
             ),
             (
@@ -188,7 +192,7 @@ class TestStandardMetadata(unittest.TestCase):
                 [
                     {
                         'metadata': {},
-                        'breadcrumb': []
+                        'breadcrumb': ()
                     }
                 ]
             ),
@@ -202,10 +206,9 @@ class TestStandardMetadata(unittest.TestCase):
                 [
                     {
                         'metadata': {
-                            'inclusion': 'available',
-                            'valid_replication_keys': ['id','created']
+                            'valid-replication-keys': ['id','created']
                         },
-                        'breadcrumb': []
+                        'breadcrumb': ()
                     }
                 ]
             ),
@@ -219,10 +222,9 @@ class TestStandardMetadata(unittest.TestCase):
                 [
                     {
                         'metadata': {
-                            'inclusion': 'available',
                             'forced-replication-method': 'INCREMENTAL'
                         },
-                        'breadcrumb': []
+                        'breadcrumb': ()
                     }
                 ]
             ),
@@ -236,11 +238,10 @@ class TestStandardMetadata(unittest.TestCase):
                 [
                     {
                         'metadata': {
-                            'inclusion': 'available',
                             'forced-replication-method': 'INCREMENTAL',
-                            'valid_replication_keys': ['id','created']
+                            'valid-replication-keys': ['id','created']
                         },
-                        'breadcrumb': []
+                        'breadcrumb': ()
                     }
                 ]
             ),
@@ -254,10 +255,9 @@ class TestStandardMetadata(unittest.TestCase):
                 [
                     {
                         'metadata': {
-                            'inclusion': 'available',
                             'table-key-properties': ['id'],
                         },
-                        'breadcrumb': []
+                        'breadcrumb': ()
                     }
                 ]
             ),
@@ -271,11 +271,10 @@ class TestStandardMetadata(unittest.TestCase):
                 [
                     {
                         'metadata': {
-                            'inclusion': 'available',
                             'table-key-properties': ['id'],
-                            'valid_replication_keys': ['id','created']
+                            'valid-replication-keys': ['id','created']
                         },
-                        'breadcrumb': []
+                        'breadcrumb': ()
                     }
                 ]
             ),
@@ -289,12 +288,11 @@ class TestStandardMetadata(unittest.TestCase):
                 [
                     {
                         'metadata': {
-                            'inclusion': 'available',
                             'table-key-properties': ['id'],
                             'forced-replication-method': 'INCREMENTAL',
-                            'valid_replication_keys': ['id','created']
+                            'valid-replication-keys': ['id','created']
                         },
-                        'breadcrumb': []
+                        'breadcrumb': ()
                     }
                 ]
             )
@@ -307,8 +305,7 @@ class TestStandardMetadata(unittest.TestCase):
             test_value = get_standard_metadata(**function_params)
 
             for obj in expected_metadata:
-                if obj in test_value:
-                    self.assertIn(obj, test_value)
+                self.assertIn(obj, test_value)
 
         # Test one function call where the parameters are not splat in
         test_value = get_standard_metadata(test_schema,
@@ -320,11 +317,11 @@ class TestStandardMetadata(unittest.TestCase):
         expected_metadata = make_expected_metadata(schema_present_base_obj,
                                                    {'table-key-properties': ['id'],
                                                     'forced-replication-method': 'INCREMENTAL',
-                                                    'valid_replication_keys': ['id','created'],
-                                                    'schema-name':tap_stream_id})
+                                                    'valid-replication-keys': ['id','created'],
+                                                    'schema-name':tap_stream_id},
+                                                    test_kp=True)
         for obj in expected_metadata:
-            if obj in test_value:
-                self.assertIn(obj, test_value)
+            self.assertIn(obj, test_value)
 
     def test_empty_key_properties_are_written(self):
         mdata = get_standard_metadata(key_properties=[])

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -34,6 +34,17 @@ def make_expected_metadata(base_obj, dict_of_extras, test_kp=False):
 class TestStandardMetadata(unittest.TestCase):
 
     def test_standard_metadata(self):
+        """
+        There's four inputs we want to test: schema, key_properties, replication_method, valid_replication_keys.
+
+        When `schema` is a non-null input, we expect `"inclusion": "available"` metadata for the `()` breadcrumb.
+
+        When `key_properties` is a non-null input, we expect `table-key-properties` metadata for the `()` breadcrumb.
+
+        When `replication_method` is a non-null input, we expect `forced-replication-method` metadata for the `()` breadcrumb.
+
+        When `valid_replication_keys` is a non-null input, we expect `valid-replication-keys` metadata for the `()` breadcrumb.
+        """
         self.maxDiff = None
 
         # Some contants shared by a number of expected metadata objects

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -218,7 +218,7 @@ class TestStandardMetadata(unittest.TestCase):
                         'metadata': {
                             'valid-replication-keys': ['id','created']
                         },
-                        'breadcrumb': ()
+                        'breadcrumb': []
                     }
                 ]
             ),
@@ -234,7 +234,7 @@ class TestStandardMetadata(unittest.TestCase):
                         'metadata': {
                             'forced-replication-method': 'INCREMENTAL'
                         },
-                        'breadcrumb': ()
+                        'breadcrumb': []
                     }
                 ]
             ),
@@ -251,7 +251,7 @@ class TestStandardMetadata(unittest.TestCase):
                             'forced-replication-method': 'INCREMENTAL',
                             'valid-replication-keys': ['id','created']
                         },
-                        'breadcrumb': ()
+                        'breadcrumb': []
                     }
                 ]
             ),
@@ -267,7 +267,7 @@ class TestStandardMetadata(unittest.TestCase):
                         'metadata': {
                             'table-key-properties': ['id'],
                         },
-                        'breadcrumb': ()
+                        'breadcrumb': []
                     }
                 ]
             ),
@@ -284,7 +284,7 @@ class TestStandardMetadata(unittest.TestCase):
                             'table-key-properties': ['id'],
                             'valid-replication-keys': ['id','created']
                         },
-                        'breadcrumb': ()
+                        'breadcrumb': []
                     }
                 ]
             ),
@@ -302,7 +302,7 @@ class TestStandardMetadata(unittest.TestCase):
                             'forced-replication-method': 'INCREMENTAL',
                             'valid-replication-keys': ['id','created']
                         },
-                        'breadcrumb': ()
+                        'breadcrumb': []
                     }
                 ]
             )


### PR DESCRIPTION
# Description of change
* Add docs
* use unittest methods to do asserts
* adds a missing test
* update expected values

This duplicates changes in #132, but I added the doc string to explain the rational behind the test, and the `self.subTest()` context manager to make the process of examining a failing test more sane.

Example test run:
```
$ python -m unittest tests/test_metadata.py
..
======================================================================
FAIL: test_standard_metadata (tests.test_metadata.TestStandardMetadata) (test_number=10)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/code/singer-python/tests/test_metadata.py", line 321, in test_standard_metadata
    self.assertDictEqual(expected_value, actual_value)
AssertionError: {(): {'inclusion': 'foo', 'forced-replication-method': 'INCREMENTAL'}} != {(): {'forced-replication-method': 'INCREMENTAL'}}
- {(): {'forced-replication-method': 'INCREMENTAL', 'inclusion': 'foo'}}
?                                                 --------------------

+ {(): {'forced-replication-method': 'INCREMENTAL'}}

----------------------------------------------------------------------
Ran 3 tests in 0.001s

FAILED (failures=1)
```

Because it's divided into sub tests now, we get an error message like this for each failing sub test. And the `(test_number=10)` in the first line tells you which input is failing. Just `grep` for `test_number=10` in the test file.

Perhaps a better approach would be to move contants into global constants and break the 1 massive test into the 16 individual tests, but @Jude188 did all of the adjustments already, so I left it that way.

# Manual QA steps
 - Ran the tests locally and they pass
 
# Risks
 - Low as the function didn't change
    - The tests had bad expected values and they were never caught because of the way the asserts were written
 
# Rollback steps
 - revert this branch
