### PR TITLE
Remove hard lock on version of jsonschema dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name="singer-python",
       url="http://singer.io",
       install_requires=[
           'pytz==2018.4',
-          'jsonschema==2.6.0',
+          'jsonschema>=2.6.0',
           'simplejson==3.11.1',
           'python-dateutil>=2.6.0',
           'backoff==1.8.0',


### PR DESCRIPTION
Make singer-python compatible with airflow 1.10.14.