### PR TITLE
Allow logging configuration to be customized

### DIFF
--- a/singer/logger.py
+++ b/singer/logger.py
@@ -6,7 +6,7 @@ import os
 def get_logger():
     """Return a Logger instance appropriate for using in a Tap or a Target."""
     this_dir, _ = os.path.split(__file__)
-    path = os.path.join(this_dir, 'logging.conf')
+    path = os.environ.get('SINGER_LOGGING_CONF') or os.path.join(this_dir, 'logging.conf')
     # See
     # https://docs.python.org/3.5/library/logging.config.html#logging.config.fileConfig
     # for a discussion of why or why not to set disable_existing_loggers


### PR DESCRIPTION
# Description of change
Allow logging behavior to be configured at runtime, by supporting a `SINGER_LOGGING_CONF` environment variable. This enables downstream developers to provide their own version of `logging.conf` to match the needs of their projects.

Without this change, logging configuration is hard coded in `logging.conf`, which is loaded within `logger.getLogger()`. This makes it very difficult to change logging settings at runtime. Even taps and targets that attempt to support customization fail to do so properly since multiple invocations of `logger.getLogger()` will simply reload the hard coded settings (target-postgres is an example).

# Manual QA steps
- Run a singer tap or target, and confirm that it logs as usual
- Copy `logging.conf` to a separate file and change the log format to something noticeably different
- Set the `SINGER_LOGGING_CONF` environment variable to contain the absolute path of your new `logging.conf`
- Run the singer tap or target again, and confirm that it logs with your customized log format
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
