### PR TITLE
allow more recent versions from jsonschema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name="singer-python",
       url="http://singer.io",
       install_requires=[
           'pytz==2018.4',
-          'jsonschema==2.6.0',
+          'jsonschema>=2.6.0',
           'simplejson==3.11.1',
           'python-dateutil>=2.6.0',
           'backoff==1.8.0',


### PR DESCRIPTION
# Description of change
`singer-python` requires `jsonschema` in version `2.6.0`.  
Version `2.6.0` is from 2017 and only supports jsonschemas up to draft 4.  
This PR sets `jsonschema` version `2.6.0` as minimum required version so newer versions are allowed.

Otherwise singer targets which use the `singer-python` package cannot use a jsonschema validator for new jsonschema versions.


# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
