### PR TITLE
remove pinned `pytz` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 5.12.2
-  * Removes pinned `pytz` version [#150](https://github.com/singer-io/singer-python/pull/150)
+  * Removes pinned `pytz` version [#152](https://github.com/singer-io/singer-python/pull/152)
 
 ## 5.12.1
   * Removes normalize function from `singer.decimal` to avoid scientific notation [#146](https://github.com/singer-io/singer-python/pull/146)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 5.12.2
+  * Removes pinned `pytz` version [#150](https://github.com/singer-io/singer-python/pull/150)
+
 ## 5.12.1
   * Removes normalize function from `singer.decimal` to avoid scientific notation [#146](https://github.com/singer-io/singer-python/pull/146)
 

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,13 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="singer-python",
-      version='5.12.1',
+      version='5.12.2',
       description="Singer.io utility library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       url="http://singer.io",
       install_requires=[
-          'pytz==2018.4',
+          'pytz',
           'jsonschema==2.6.0',
           'simplejson==3.11.1',
           'python-dateutil>=2.6.0',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name="singer-python",
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       url="http://singer.io",
       install_requires=[
-          'pytz',
+          'pytz>=2018.4',
           'jsonschema==2.6.0',
           'simplejson==3.11.1',
           'python-dateutil>=2.6.0',


### PR DESCRIPTION
# Description of change
Update `pytz` version to >=2018.4

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
