### PR TITLE
Relax version of backoff dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name="singer-python",
           'jsonschema==2.6.0',
           'simplejson==3.11.1',
           'python-dateutil>=2.6.0',
-          'backoff==1.8.0',
+          'backoff>=1.8.0,<2',
 	  'ciso8601',
       ],
       extras_require={


### PR DESCRIPTION
# Description of change
Relax the required version of backoff in order to enable it to work with libraries that require newer versions

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
