### PR TITLE
parse dev mode argument

### DIFF
--- a/singer/utils.py
+++ b/singer/utils.py
@@ -134,6 +134,7 @@ def parse_args(required_config_keys):
     -d,--discover   Run in discover mode
     -p,--properties Properties file: DEPRECATED, please use --catalog instead
     --catalog       Catalog file
+    -dev, --dev     Runs the tap in dev mode
 
     Returns the parsed args object from argparse. For each argument that
     point to JSON files (config, state, properties), we will automatically
@@ -162,6 +163,11 @@ def parse_args(required_config_keys):
         '-d', '--discover',
         action='store_true',
         help='Do schema discovery')
+
+    parser.add_argument(
+        '-dev', '--dev',
+        action='store_true',
+        help='Runs tap in dev mode')
 
     args = parser.parse_args()
     if args.config:

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -165,7 +165,7 @@ def parse_args(required_config_keys):
         help='Do schema discovery')
 
     parser.add_argument(
-        '-dev', '--dev',
+        '-D', '--dev',
         action='store_true',
         help='Runs tap in dev mode')
 

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -40,7 +40,7 @@ def strptime(dtime):
       ...
     ValueError: time data '2018-01-01T00:00:00' does not match format '%Y-%m-%dT%H:%M:%SZ'
 
-    Can't parse non-UTC DTsx
+    Can't parse non-UTC DTs
     >>> strptime("2018-01-01T00:00:00-04:00")
     Traceback (most recent call last):
       ...
@@ -134,7 +134,7 @@ def parse_args(required_config_keys):
     -d,--discover   Run in discover mode
     -p,--properties Properties file: DEPRECATED, please use --catalog instead
     --catalog       Catalog file
-    -D, --dev     Runs the tap in dev mode
+    --dev     Runs the tap in dev mode
 
     Returns the parsed args object from argparse. For each argument that
     point to JSON files (config, state, properties), we will automatically
@@ -165,7 +165,7 @@ def parse_args(required_config_keys):
         help='Do schema discovery')
 
     parser.add_argument(
-        '-D', '--dev',
+        '--dev',
         action='store_true',
         help='Runs tap in dev mode')
 

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -40,7 +40,7 @@ def strptime(dtime):
       ...
     ValueError: time data '2018-01-01T00:00:00' does not match format '%Y-%m-%dT%H:%M:%SZ'
 
-    Can't parse non-UTC DTs
+    Can't parse non-UTC DTsx
     >>> strptime("2018-01-01T00:00:00-04:00")
     Traceback (most recent call last):
       ...
@@ -134,7 +134,7 @@ def parse_args(required_config_keys):
     -d,--discover   Run in discover mode
     -p,--properties Properties file: DEPRECATED, please use --catalog instead
     --catalog       Catalog file
-    -dev, --dev     Runs the tap in dev mode
+    -D, --dev     Runs the tap in dev mode
 
     Returns the parsed args object from argparse. For each argument that
     point to JSON files (config, state, properties), we will automatically


### PR DESCRIPTION
# Description of change
This implementation adds support to parse dev mode arguments `-D` or `--dev` in cmdline.

# Manual QA steps
 - Manually updated tap singer-python library and from orchestrator tested the discovery with `-D` and `--dev` on an existing connection.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
