### PR TITLE
Use `importlib.resources` default config file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(name="singer-python",
           'simplejson==3.11.1',
           'python-dateutil>=2.6.0',
           'backoff==1.8.0',
-	  'ciso8601',
+          'ciso8601',
+          'importlib-resources>=1.3; python_version<"3.9"',
       ],
       extras_require={
           'dev': [

--- a/singer/logger.py
+++ b/singer/logger.py
@@ -1,19 +1,24 @@
 import logging
 import logging.config
-import os
+import sys
+
+if sys.version_info < (3, 9):
+    import importlib_resources
+else:
+    from importlib import resources as importlib_resources
 
 
 def get_logger():
     """Return a Logger instance appropriate for using in a Tap or a Target."""
-    this_dir, _ = os.path.split(__file__)
-    path = os.path.join(this_dir, 'logging.conf')
+    path = importlib_resources.files(__package__).joinpath('logging.conf')
     # See
     # https://docs.python.org/3.5/library/logging.config.html#logging.config.fileConfig
     # for a discussion of why or why not to set disable_existing_loggers
     # to False. The long and short of it is that if you don't set it to
     # False it ruins external module's abilities to use the logging
     # facility.
-    logging.config.fileConfig(path, disable_existing_loggers=False)
+    with path.open() as f:
+        logging.config.fileConfig(f, disable_existing_loggers=False)
     return logging.getLogger()
 
 


### PR DESCRIPTION
# Description of change

This allows packaging Singer taps and targets as [_zipapps_](https://docs.python.org/3/library/zipapp.html), which can be executed directly by a Python interpreter without needing to install any dependencies:

```console
$ python3 tap-surveymonkey.pyz --config config.json --discover > catalog.json
```

Otherwise errors like this are raised:

```console
$ python3 target-jsonl.pyz --help
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/projects/target-jsonl/target-jsonl.pyz/__main__.py", line 2, in <module>
  File "/projects/target-jsonl/target-jsonl.pyz/target_jsonl.py", line 12, in <module>
  File "/projects/target-jsonl/target-jsonl.pyz/singer/__init__.py", line 1, in <module>
  File "/projects/target-jsonl/target-jsonl.pyz/singer/utils.py", line 13, in <module>
  File "/projects/target-jsonl/target-jsonl.pyz/singer/catalog.py", line 10, in <module>
  File "/projects/target-jsonl/target-jsonl.pyz/singer/logger.py", line 16, in get_logger
  File "/Users/personal/.pyenv/versions/3.11.7/lib/python3.11/logging/config.py", line 65, in fileConfig
    raise FileNotFoundError(f"{fname} doesn't exist")
FileNotFoundError: /projects/target-jsonl/target-jsonl.pyz/singer/logging.conf doesn't exist
```

With this change:

```console
$ python3 target-jsonl.pyz --help
usage: target-jsonl.pyz [-h] [-c CONFIG]

options:
  -h, --help            show this help message and exit
  -c CONFIG, --config CONFIG
                        Config file
```

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
