### PR TITLE
Bump backoff to be compatible with newer python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,22 @@
-version: 2
+version: 2.1
+
+workflows:
+  build:
+    jobs:
+      - build:
+          context:
+            - circleci-user
+
 jobs:
   build:
     docker:
-      - image: ubuntu:16.04
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/sources-python:1.1.0
     steps:
       - checkout
       - run:
-          name: 'Install python 3.5.2'
-          command: |
-            apt update
-            apt install --yes python3 python3-pip python3-venv
-      - run:
           name: 'Setup virtualenv'
           command: |
-            mkdir -p ~/.virtualenvs
+            pyenv global 3.11.7
             python3 -m venv ~/.virtualenvs/singer-python
             source ~/.virtualenvs/singer-python/bin/activate
             pip install -U 'pip<20.3.4' 'setuptools<51.0.0'
@@ -21,6 +24,5 @@ jobs:
       - run:
           name: 'Run tests'
           command: |
-            # Need to re-activate the virtualenv
             source ~/.virtualenvs/singer-python/bin/activate
             make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           command: |
             source ~/.virtualenvs/singer-python/bin/activate
             pip install pylint
-            pylint singer --extension-pkg-whitelist=ciso8601 -d missing-docstring,broad-except,bare-except,too-many-return-statements,too-many-branches,too-many-arguments,no-else-return,too-few-public-methods,fixme,protected-access
+            pylint singer --extension-pkg-whitelist=ciso8601 -d missing-docstring,broad-exception-raised,bare-except,too-many-return-statements,too-many-branches,too-many-arguments,no-else-return,too-few-public-methods,fixme,protected-access
       - run:
           name: 'Run Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           command: |
             source ~/.virtualenvs/singer-python/bin/activate
             pip install pylint
-            pylint singer --extension-pkg-whitelist=ciso8601 -d missing-docstring,broad-exception-raised,bare-except,too-many-return-statements,too-many-branches,too-many-arguments,no-else-return,too-few-public-methods,fixme,protected-access,consider-using-f-string
+            pylint singer --extension-pkg-whitelist=ciso8601 -d missing-docstring,broad-exception-raised,broad-exception-caught,bare-except,too-many-return-statements,too-many-branches,too-many-arguments,no-else-return,too-few-public-methods,fixme,protected-access,consider-using-f-string
       - run:
           name: 'Run Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,17 @@ jobs:
             pyenv global 3.11.7
             python3 -m venv ~/.virtualenvs/singer-python
             source ~/.virtualenvs/singer-python/bin/activate
-            pip install -U 'pip<20.3.4' 'setuptools<51.0.0'
-            make install
+            pip install -U 'pip==20.3.4' 'setuptools<51.0.0'
+            pip install .[dev]
       - run:
-          name: 'Run tests'
+          name: 'Pylint'
           command: |
             source ~/.virtualenvs/singer-python/bin/activate
-            make test
+            pip install pylint
+            pylint singer --extension-pkg-whitelist=ciso8601 -d missing-docstring,broad-except,bare-except,too-many-return-statements,too-many-branches,too-many-arguments,no-else-return,too-few-public-methods,fixme,protected-access
+      - run:
+          name: 'Run Tests'
+          command: |
+            source ~/.virtualenvs/singer-python/bin/activate
+            pip install nose2
+            nose2 -v -s tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           command: |
             source ~/.virtualenvs/singer-python/bin/activate
             pip install pylint
-            pylint singer --extension-pkg-whitelist=ciso8601 -d missing-docstring,broad-exception-raised,bare-except,too-many-return-statements,too-many-branches,too-many-arguments,no-else-return,too-few-public-methods,fixme,protected-access
+            pylint singer --extension-pkg-whitelist=ciso8601 -d missing-docstring,broad-exception-raised,bare-except,too-many-return-statements,too-many-branches,too-many-arguments,no-else-return,too-few-public-methods,fixme,protected-access,consider-using-f-string
       - run:
           name: 'Run Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             mkdir -p ~/.virtualenvs
             python3 -m venv ~/.virtualenvs/singer-python
             source ~/.virtualenvs/singer-python/bin/activate
-            pip install -U 'pip<19.2' 'setuptools<51.0.0'
+            pip install -U 'pip<20.3.4' 'setuptools<51.0.0'
             make install
       - run:
           name: 'Run tests'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.0.0
+  * Bump backoff version to 2.2.1. This version drops support for python 3.5, but adds it for 3.1o [#165](https://github.com/singer-io/singer-python/pull/165)
+
 ## 5.13.0
   * Add support for dev mode argument parsing [#158](https://github.com/singer-io/singer-python/pull/158)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="singer-python",
-      version='5.14.0',
+      version='6.0.0',
       description="Singer.io utility library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="singer-python",
-      version='5.13.0',
+      version='5.14.0',
       description="Singer.io utility library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],
@@ -14,7 +14,7 @@ setup(name="singer-python",
           'jsonschema==2.6.0',
           'simplejson==3.11.1',
           'python-dateutil>=2.6.0',
-          'backoff==1.8.0',
+          'backoff==2.2.1',
 	  'ciso8601',
       ],
       extras_require={

--- a/singer/catalog.py
+++ b/singer/catalog.py
@@ -92,7 +92,7 @@ class Catalog():
 
     @classmethod
     def load(cls, filename):
-        with open(filename) as fp:  # pylint: disable=invalid-name
+        with open(filename, encoding="utf-8") as fp:
             return Catalog.from_dict(json.load(fp))
 
     @classmethod

--- a/singer/exceptions.py
+++ b/singer/exceptions.py
@@ -11,7 +11,7 @@ class SingerError(Exception):
         The first line is the error's class name. The subsequent lines are
         the message that class was created with.
         """
-        super().__init__('{}\n{}'.format(self.__class__.__name__, message))
+        super().__init__(f'{(self.__class__.__name__}\n{message}')
 
 
 class SingerConfigurationError(SingerError):

--- a/singer/exceptions.py
+++ b/singer/exceptions.py
@@ -11,7 +11,7 @@ class SingerError(Exception):
         The first line is the error's class name. The subsequent lines are
         the message that class was created with.
         """
-        super().__init__(f'{(self.__class__.__name__}\n{message}')
+        super().__init__(f"{self.__class__.__name__}\n{message}")
 
 
 class SingerConfigurationError(SingerError):

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -11,16 +11,16 @@ LOGGER = get_logger()
 class Message():
     '''Base class for messages.'''
 
-    def asdict(self):  # pylint: disable=no-self-use
+    def asdict(self):
         raise Exception('Not implemented')
 
     def __eq__(self, other):
         return isinstance(other, Message) and self.asdict() == other.asdict()
 
     def __repr__(self):
-        pairs = ["{}={}".format(k, v) for k, v in self.asdict().items()]
+        pairs = [f"{k}={v}" for k, v in self.asdict().items()]
         attrstr = ", ".join(pairs)
-        return "{}({})".format(self.__class__.__name__, attrstr)
+        return f"{self.__class__.__name__}({attrstr})"
 
     def __str__(self):
         return str(self.asdict())
@@ -169,7 +169,7 @@ class ActivateVersionMessage(Message):
 
 def _required_key(msg, k):
     if k not in msg:
-        raise Exception("Message is missing required key '{}': {}".format(k, msg))
+        raise Exception(f"Message is missing required key '{k}': {msg}"
 
     return msg[k]
 

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -169,7 +169,7 @@ class ActivateVersionMessage(Message):
 
 def _required_key(msg, k):
     if k not in msg:
-        raise Exception(f"Message is missing required key '{k}': {msg}"
+        raise Exception(f"Message is missing required key '{k}': {msg}")
 
     return msg[k]
 

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -54,8 +54,8 @@ class SchemaMismatch(Exception):
 
         else:
             estrs = [e.tostr() for e in errors]
-            msg = "Errors during transform\n\t{}".format("\n\t".join(estrs))
-            msg += "\n\n\nErrors during transform: [{}]".format(", ".join(estrs))
+            msg = f"Errors during transform\n\t{"\n\t".join(estrs)}"
+            msg += f"\n\n\nErrors during transform: [{", ".join(estrs)}]"
 
         super().__init__(msg)
 
@@ -77,16 +77,16 @@ class Error:
         path = ".".join(map(str, self.path))
         if self.schema:
             if self.logging_level >= logging.INFO:
-                msg = "data does not match {}".format(self.schema)
+                msg = f"data does not match {self.schema}"
             else:
-                msg = "does not match {}".format(self.schema)
+                msg = f"does not match {self.schema}"
         else:
             msg = "not in schema"
 
         if self.logging_level >= logging.INFO:
-            output = "{}: {}".format(path, msg)
+            output = f"{path}: {msg}"
         else:
-            output = "{}: {} {}".format(path, self.data, msg)
+            output = f"{path}: {self.data} {msg}"
         return output
 
 

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -54,8 +54,8 @@ class SchemaMismatch(Exception):
 
         else:
             estrs = [e.tostr() for e in errors]
-            msg = f"Errors during transform\n\t{"\n\t".join(estrs)}"
-            msg += f"\n\n\nErrors during transform: [{", ".join(estrs)}]"
+            msg = "Errors during transform\n\t{}".format("\n\t".join(estrs))
+            msg += "\n\n\nErrors during transform: [{}]".format(", ".join(estrs))
 
         super().__init__(msg)
 

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -105,7 +105,7 @@ def chunk(array, num):
 
 
 def load_json(path):
-    with open(path) as fil:
+    with open(path, encoding="utf-8") as fil:
         return json.load(fil)
 
 
@@ -193,7 +193,7 @@ def parse_args(required_config_keys):
 def check_config(config, required_keys):
     missing_keys = [key for key in required_keys if key not in config]
     if missing_keys:
-        raise Exception("Config is missing required keys: {}".format(missing_keys))
+        raise Exception(f"Config is missing required keys: {missing_keys}"
 
 
 def backoff(exceptions, giveup):

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -193,7 +193,7 @@ def parse_args(required_config_keys):
 def check_config(config, required_keys):
     missing_keys = [key for key in required_keys if key not in config]
     if missing_keys:
-        raise Exception(f"Config is missing required keys: {missing_keys}"
+        raise Exception(f"Config is missing required keys: {missing_keys}")
 
 
 def backoff(exceptions, giveup):


### PR DESCRIPTION
# Description of change
Bumps backoff from `1.8.0` to `2.2.1`. In the new major version backoff drops support for [python 3.5, but adds it for 3.10+ ](https://github.com/litl/backoff/blob/master/CHANGELOG.md#v200---2022-04-26). 
This is a major version bump, since taps running python 3.5 will no longer work.

Updates circle config to be compatible with newer python versions, and pylint updates. 

# Manual QA steps
 - Tested locally with tap-mixpanel
 
# Risks
 - Taps running on python 3.5 will not be able to use this version
 
# Rollback steps
 - revert this branch
