### PR TITLE
Relax dependency version requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## 6.0.1
+  * Pin backoff and simplejson to any version greater than or equal to the previously allowed version, up to the next major version [#167](https://github.com/singer-io/singer-python/pull/167)
+
 ## 6.0.0
-  * Bump backoff version to 2.2.1. This version drops support for python 3.5, but adds it for 3.1o [#165](https://github.com/singer-io/singer-python/pull/165)
+  * Bump backoff version to 2.2.1. This version drops support for python 3.5, but adds it for 3.10 [#165](https://github.com/singer-io/singer-python/pull/165)
 
 ## 5.13.0
   * Add support for dev mode argument parsing [#158](https://github.com/singer-io/singer-python/pull/158)

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,10 @@ setup(name="singer-python",
       url="http://singer.io",
       install_requires=[
           'pytz>=2018.4',
-          'jsonschema>=2.6.0',
-          'simplejson>=3.19.2',
+          'jsonschema==2.6.0',
+          'simplejson==3.*',
           'python-dateutil>=2.6.0',
-          'backoff>=2.2.1',
+          'backoff==2.*',
           'ciso8601',
       ],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ setup(name="singer-python",
       install_requires=[
           'pytz>=2018.4',
           'jsonschema==2.6.0',
-          'simplejson==3.*',
+          'simplejson>=3.11.1,==3.*',
           'python-dateutil>=2.6.0',
-          'backoff==2.*',
+          'backoff>=2.2.1,==2.*',
           'ciso8601',
       ],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="singer-python",
-      version='6.0.0',
+      version='6.0.1',
       description="Singer.io utility library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ setup(name="singer-python",
       url="http://singer.io",
       install_requires=[
           'pytz>=2018.4',
-          'jsonschema==2.6.0',
-          'simplejson==3.11.1',
+          'jsonschema>=2.6.0',
+          'simplejson>=3.19.2',
           'python-dateutil>=2.6.0',
-          'backoff==2.2.1',
-	  'ciso8601',
+          'backoff>=2.2.1',
+          'ciso8601',
       ],
       extras_require={
           'dev': [

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ setup(name="singer-python",
       url="http://singer.io",
       install_requires=[
           'pytz>=2018.4',
-          'jsonschema==2.6.0',
-          'simplejson>=3.11.1,==3.*',
-          'python-dateutil>=2.6.0',
+          'jsonschema>=2.6.0,==2.*',
+          'simplejson>=3.13.2,==3.*',
+          'python-dateutil>=2.7.3,==2.*',
           'backoff>=2.2.1,==2.*',
-          'ciso8601',
+          'ciso8601>=2.3.1,==2.*',
       ],
       extras_require={
           'dev': [


### PR DESCRIPTION
# Description of change
Pin simplejson and backoff to _only_ their major versions

# Manual QA steps
 - Verified extraction succeeds with tap using `singer-python` as dependency
 
# Risks
 - Low. Pinning dependencies to a major version should not cause breaking changes.
 
# Rollback steps
 - revert this branch
