### PR TITLE
Make `ensure_ascii` Dynamic with Default Set to `True` in JSON Serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.1.0
+  * Make ensure_ascii Dynamic with Default Set to True in JSON Serialization. Required to handle the special characters [#168](https://github.com/singer-io/singer-python/pull/168)
+
 ## 6.0.1
   * Pin backoff and simplejson to any version greater than or equal to the previously allowed version, up to the next major version [#167](https://github.com/singer-io/singer-python/pull/167)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="singer-python",
-      version='6.0.1',
+      version='6.1.0',
       description="Singer.io utility library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -218,12 +218,12 @@ def parse_message(msg):
         return None
 
 
-def format_message(message):
-    return json.dumps(message.asdict(), use_decimal=True)
+def format_message(message, ensure_ascii=True):
+    return json.dumps(message.asdict(), use_decimal=True, ensure_ascii=ensure_ascii)
 
 
-def write_message(message):
-    sys.stdout.write(format_message(message) + '\n')
+def write_message(message, ensure_ascii=True):
+    sys.stdout.write(format_message(message, ensure_ascii=ensure_ascii) + '\n')
     sys.stdout.flush()
 
 


### PR DESCRIPTION
# Description of change
This PR introduces a dynamic setting for the ensure_ascii parameter in the `json.dumps` function, with its default value set to `True`. This change allows for greater flexibility in JSON serialization, enabling non-ASCII characters to be preserved when needed by explicitly passing `ensure_ascii=False`.

# Manual QA steps
 - Unit Tests: Added and updated unit tests to verify the correct behaviour of JSON serialization with both ensure_ascii=True (default) and ensure_ascii=False.
 - Alpha: Performed PR-alpha on the customer connection to test JSON serialization for the special characters
 
# Risks
 - If not ensure_ascii is set differently per the expectations within the tap code, then customers can experience the data discrepancy.
 
# Rollback steps
 - revert this branch
