### PR TITLE
Use the underscore name `description_file` in `setup.cfg` instead of deprecated `description-file`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
# Description of change

setuptools recently made a breaking change:

- https://github.com/pypa/setuptools/pull/4870
- https://github.com/pypa/setuptools/issues/4910
- https://github.com/pypa/setuptools/pull/4911

# Manual QA steps

```
virtualenv .venv
source .venv/bin/activate
pip install -e .
```
 
# Risks
 - Maybe some folks get a really old (~2021) setuptools installed in their toolchain and this breaks them? Haven't confirmed yet.
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
