### PR TITLE
Use underscore instead of dash in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="singer-python",
-      version='6.1.0',
+      version='6.1.1',
       description="Singer.io utility library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Any project depending on singer-python failed to build due to a dash in `setup.cfg` for a few hours because of [this setuptools issue](https://github.com/pypa/setuptools/issues/4910).

They postponed the removal of the deprecation until 2026.

# Manual QA steps
 - N/A
 
# Risks
 - The only risk is not updating.
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
