### PR TITLE
export singer.state functions from main module v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.16.1
+  * Export state version functions from main module [#191](https://github.com/singer-io/singer-python/pull/191)
+
 ## 5.16.0
   * Add `activate_versions` state functions [#189](https://github.com/singer-io/singer-python/pull/189)
   * Deprecates bookmarks.py, functions are moved to state.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## 5.16.1
-  * Export state version functions from main module [#191](https://github.com/singer-io/singer-python/pull/191)
+## 5.17.0
+  * Export state version functions from main module
+  * Rename singer.state.write_bookmark to singer.state.set_bookmark
+  * [#191](https://github.com/singer-io/singer-python/pull/191)
 
 ## 5.16.0
   * Add `activate_versions` state functions [#189](https://github.com/singer-io/singer-python/pull/189)

--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,5 @@ install: check_prereqs
 	python3 -m pip install -e '.[dev]'
 
 test: install
-	pylint singer --extension-pkg-whitelist=ciso8601 -d missing-docstring,broad-except,bare-except,too-many-return-statements,too-many-branches,too-many-arguments,no-else-return,too-few-public-methods,fixme,protected-access
+	pylint singer --extension-pkg-whitelist=ciso8601 -d missing-docstring,broad-except,bare-except,too-many-return-statements,too-many-branches,too-many-arguments,no-else-return,too-few-public-methods,fixme,protected-access,reimported
 	nosetests --with-doctest -v

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="singer-python",
-      version='5.16.1',
+      version='5.17.0',
       description="Singer.io utility library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="singer-python",
-      version='5.16.0',
+      version='5.16.1',
       description="Singer.io utility library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/singer/__init__.py
+++ b/singer/__init__.py
@@ -61,7 +61,7 @@ from singer.catalog import (
 )
 from singer.schema import Schema
 
-from singer.bookmarks import (
+from singer.state import (
     write_bookmark,
     get_bookmark,
     clear_bookmark,
@@ -71,6 +71,9 @@ from singer.bookmarks import (
     get_offset,
     set_currently_syncing,
     get_currently_syncing,
+    write_version,
+    clear_version,
+    get_version,
 )
 
 from singer.exceptions import (

--- a/singer/__init__.py
+++ b/singer/__init__.py
@@ -62,7 +62,9 @@ from singer.catalog import (
 from singer.schema import Schema
 
 from singer.state import (
-    write_bookmark,
+    set_bookmark,
+    # for backwards compatibility, use set_bookmark instead
+    set_bookmark as write_bookmark,
     get_bookmark,
     clear_bookmark,
     reset_stream,
@@ -71,7 +73,7 @@ from singer.state import (
     get_offset,
     set_currently_syncing,
     get_currently_syncing,
-    write_version,
+    set_version,
     clear_version,
     get_version,
 )

--- a/singer/bookmarks.py
+++ b/singer/bookmarks.py
@@ -6,7 +6,7 @@ def ensure_bookmark_path(state, path):
     return st.ensure_state_path(state, path)
 
 def write_bookmark(state, tap_stream_id, key, val):
-    return st.write_bookmark(state, tap_stream_id, key, val)
+    return st.set_bookmark(state, tap_stream_id, key, val)
 
 def clear_bookmark(state, tap_stream_id, key):
     return st.clear_bookmark(state, tap_stream_id, key)

--- a/singer/state.py
+++ b/singer/state.py
@@ -7,7 +7,7 @@ def ensure_state_path(state, path):
         submap = submap[path_component]
     return state
 
-def write_bookmark(state, tap_stream_id, key, val):
+def set_bookmark(state, tap_stream_id, key, val):
     state = ensure_state_path(state, ['bookmarks', tap_stream_id])
     state['bookmarks'][tap_stream_id][key] = val
     return state
@@ -46,7 +46,7 @@ def set_currently_syncing(state, tap_stream_id):
 def get_currently_syncing(state, default=None):
     return state.get('currently_syncing', default)
 
-def write_version(state, tap_stream_id, key, val):
+def set_version(state, tap_stream_id, key, val):
     state = ensure_state_path(state, ['activate_versions', tap_stream_id])
     state['activate_versions'][tap_stream_id][key] = val
     return state

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,7 +1,7 @@
 import unittest
 from singer import state as st
 
-class TestGetBookmark(unittest.TestCase):
+class TestBookmark(unittest.TestCase):
     def test_empty_state(self):
         empty_state = {}
 
@@ -69,8 +69,24 @@ class TestGetBookmark(unittest.TestCase):
         self.assertEqual(st.get_bookmark(non_empty_state, stream_id_1, bookmark_key_1, 'default_value'),
                          bookmark_val_1)
 
+    def test_set_bookmark(self):
+        stream_id_1 = 'customers'
+        bookmark_key_1 = 'datetime'
+        bookmark_val_1 = 123456789
 
-class TestGetOffset(unittest.TestCase):
+        result = st.set_bookmark({'bookmarks': {stream_id_1: {bookmark_key_1: 'old-value'}}}, stream_id_1, bookmark_key_1, bookmark_val_1)
+        self.assertEqual(result, {'bookmarks': {stream_id_1: {bookmark_key_1: bookmark_val_1}}})
+
+    def test_clear_bookmark(self):
+        stream_id_1 = 'customers'
+        bookmark_key_1 = 'datetime'
+        bookmark_val_1 = 123456789
+
+        result = st.clear_bookmark({'bookmarks': {stream_id_1: {bookmark_key_1: bookmark_val_1}}}, stream_id_1, bookmark_key_1)
+        self.assertEqual(result, {'bookmarks': {stream_id_1: {}}})
+
+
+class TestOffset(unittest.TestCase):
     def test_empty_state(self):
         empty_state = {}
 
@@ -129,8 +145,24 @@ class TestGetOffset(unittest.TestCase):
         self.assertEqual(st.get_offset(non_empty_state, stream_id_1, 'default_value'),
                          offset_val)
 
+    def test_set_offset(self):
+        stream_id_1 = 'customers'
+        offset_key_1 = 'datetime'
+        offset_val_1 = 123456789
 
-class TestGetCurrentlySyncing(unittest.TestCase):
+        result = st.set_offset({'bookmarks': {stream_id_1: {'offset': {offset_key_1: 'old-value'}}}}, stream_id_1, offset_key_1, offset_val_1)
+        self.assertEqual(result, {'bookmarks': {stream_id_1: {'offset': {offset_key_1: offset_val_1}}}})
+
+    def test_clear_offset(self):
+        stream_id_1 = 'customers'
+        offset_key_1 = 'datetime'
+        offset_val_1 = 123456789
+
+        result = st.clear_offset({'bookmarks': {stream_id_1: {'offset': {offset_key_1: offset_val_1}}}}, stream_id_1)
+        self.assertEqual(result, {'bookmarks': {stream_id_1: {}}})
+
+
+class TestCurrentlySyncing(unittest.TestCase):
     def test_empty_state(self):
         empty_state = {}
 
@@ -164,6 +196,10 @@ class TestGetCurrentlySyncing(unittest.TestCase):
         # Case with a given default
         self.assertEqual(st.get_currently_syncing(non_empty_state, 'default_value'),
                          stream_id_1)
+
+    def test_set_currently_syncing(self):
+        result = st.set_currently_syncing({'currently_syncing': 'foo'}, 'bar')
+        self.assertEqual(result, {'currently_syncing': 'bar'})
 
 
 class TestActivateVersion(unittest.TestCase):
@@ -233,3 +269,19 @@ class TestActivateVersion(unittest.TestCase):
         # Good stream, good key
         self.assertEqual(st.get_version(non_empty_state, stream_id_1, version_key_1, 'default_value'),
                          version_val_1)
+
+    def test_set_version(self):
+        stream_id_1 = 'customers'
+        version_key_1 = 'datetime'
+        version_val_1 = 123456789
+
+        result = st.set_version({'activate_versions': {stream_id_1: {version_key_1: 'old-value'}}}, stream_id_1, version_key_1, version_val_1)
+        self.assertEqual(result, {'activate_versions': {stream_id_1: {version_key_1: version_val_1}}})
+
+    def test_clear_version(self):
+        stream_id_1 = 'customers'
+        version_key_1 = 'datetime'
+        version_val_1 = 123456789
+
+        result = st.clear_version({'activate_versions': {stream_id_1: {version_key_1: version_val_1}}}, stream_id_1, version_key_1)
+        self.assertEqual(result, {'activate_versions': {stream_id_1: {}}})


### PR DESCRIPTION
# Description of change
  * Export singer.state functions from singer
  * Rename singer.state.write_bookmark to singer.state.set_bookmark

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
