### PR TITLE
SAC-30196: remove key from version functions v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.18.0
+  * Remove `key` from version state functions [#193](https://github.com/singer-io/singer-python/pull/193)
+
 ## 5.17.0
   * Export state version functions from main module
   * Rename singer.state.write_bookmark to singer.state.set_bookmark

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="singer-python",
-      version='5.17.0',
+      version='5.18.0',
       description="Singer.io utility library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/singer/state.py
+++ b/singer/state.py
@@ -46,15 +46,15 @@ def set_currently_syncing(state, tap_stream_id):
 def get_currently_syncing(state, default=None):
     return state.get('currently_syncing', default)
 
-def set_version(state, tap_stream_id, key, val):
+def set_version(state, tap_stream_id, val):
     state = ensure_state_path(state, ['activate_versions', tap_stream_id])
-    state['activate_versions'][tap_stream_id][key] = val
+    state['activate_versions'][tap_stream_id] = val
     return state
 
-def clear_version(state, tap_stream_id, key):
+def clear_version(state, tap_stream_id):
     state = ensure_state_path(state, ['activate_versions', tap_stream_id])
-    state['activate_versions'][tap_stream_id].pop(key, None)
+    state['activate_versions'].pop(tap_stream_id, None)
     return state
 
-def get_version(state, tap_stream_id, key, default=None):
-    return state.get('activate_versions', {}).get(tap_stream_id, {}).get(key, default)
+def get_version(state, tap_stream_id, default=None):
+    return state.get('activate_versions', {}).get(tap_stream_id, default)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -207,32 +207,29 @@ class TestActivateVersion(unittest.TestCase):
         empty_state = {}
 
         # Case with no value to fall back on
-        self.assertIsNone(st.get_version(empty_state, 'some_stream', 'my_key'))
+        self.assertIsNone(st.get_version(empty_state, 'some_stream'))
 
         # Case with a given default
-        self.assertEqual(st.get_version(empty_state, 'some_stream', 'my_key', 'default_value'),
+        self.assertEqual(st.get_version(empty_state, 'some_stream', 'default_value'),
                          'default_value')
 
     def test_empty_activate_versions(self):
         empty_versions = {'activate_versions':{}}
 
         # Case with no value to fall back on
-        self.assertIsNone(st.get_version(empty_versions, 'some_stream', 'my_key'))
+        self.assertIsNone(st.get_version(empty_versions, 'some_stream'))
 
         # Case with a given default
-        self.assertEqual(st.get_version(empty_versions, 'some_stream', 'my_key', 'default_value'),
+        self.assertEqual(st.get_version(empty_versions, 'some_stream', 'default_value'),
                          'default_value')
 
     def test_non_empty_state(self):
         stream_id_1 = 'customers'
-        version_key_1 = 'version'
         version_val_1 = 123456789
 
         non_empty_state = {
             'activate_versions' : {
-                stream_id_1 : {
-                    version_key_1 : version_val_1
-                }
+                stream_id_1 : version_val_1
             }
         }
 
@@ -240,48 +237,35 @@ class TestActivateVersion(unittest.TestCase):
         # Cases with no value to fall back on
         #
 
-        # Bad stream, bad key
-        self.assertIsNone(st.get_version(non_empty_state, 'some_stream', 'my_key'))
+        # Bad stream
+        self.assertIsNone(st.get_version(non_empty_state, 'some_stream'))
 
-        # Good stream, bad key
-        self.assertIsNone(st.get_version(non_empty_state, stream_id_1, 'my_key'))
-
-        # Good stream, good key
-        self.assertEqual(st.get_version(non_empty_state, stream_id_1, version_key_1),
+        # Good stream
+        self.assertEqual(st.get_version(non_empty_state, stream_id_1),
                          version_val_1)
 
         #
         # Cases with a given default
         #
 
-        # Bad stream, bad key
-        self.assertEqual(st.get_version(non_empty_state, 'some_stream', 'my_key', 'default_value'),
+        # Bad stream
+        self.assertEqual(st.get_version(non_empty_state, 'some_stream', 'default_value'),
                          'default_value')
 
-        # Bad stream, good key
-        self.assertEqual(st.get_version(non_empty_state, 'some_stream', version_key_1, 'default_value'),
-                         'default_value')
-
-        # Good stream, bad key
-        self.assertEqual(st.get_version(non_empty_state, stream_id_1, 'my_key', 'default_value'),
-                         'default_value')
-
-        # Good stream, good key
-        self.assertEqual(st.get_version(non_empty_state, stream_id_1, version_key_1, 'default_value'),
+        # Good stream
+        self.assertEqual(st.get_version(non_empty_state, stream_id_1, 'default_value'),
                          version_val_1)
 
     def test_set_version(self):
         stream_id_1 = 'customers'
-        version_key_1 = 'datetime'
         version_val_1 = 123456789
 
-        result = st.set_version({'activate_versions': {stream_id_1: {version_key_1: 'old-value'}}}, stream_id_1, version_key_1, version_val_1)
-        self.assertEqual(result, {'activate_versions': {stream_id_1: {version_key_1: version_val_1}}})
+        result = st.set_version({'activate_versions': {stream_id_1: 'old-value'}}, stream_id_1, version_val_1)
+        self.assertEqual(result, {'activate_versions': {stream_id_1: version_val_1}})
 
     def test_clear_version(self):
         stream_id_1 = 'customers'
-        version_key_1 = 'datetime'
         version_val_1 = 123456789
 
-        result = st.clear_version({'activate_versions': {stream_id_1: {version_key_1: version_val_1}}}, stream_id_1, version_key_1)
-        self.assertEqual(result, {'activate_versions': {stream_id_1: {}}})
+        result = st.clear_version({'activate_versions': {stream_id_1: version_val_1}}, stream_id_1)
+        self.assertEqual(result, {'activate_versions': {}})


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-30196
Update `set_version`, `get_version`, and `clear_version` to remove `key`.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
