### PR TITLE
SAC-30196: Rename `activate_versions` key to `versions` in state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.8.0
+  * Rename state key `activate_versions` to `versions` in all relevant locations [#194](https://github.com/singer-io/singer-python/pull/194)
+
 ## 6.7.0
   * Remove `key` from set_version, get_version, and clear_version state functions [#192](https://github.com/singer-io/singer-python/pull/192)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="singer-python",
-      version='6.7.0',
+      version='6.8.0',
       description="Singer.io utility library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/singer/state.py
+++ b/singer/state.py
@@ -20,9 +20,9 @@ def clear_bookmark(state, tap_stream_id, key):
 def reset_stream(state, tap_stream_id):
     state = ensure_state_path(state, ['bookmarks', tap_stream_id])
     state['bookmarks'][tap_stream_id] = {}
-    if 'activate_versions' in state:
-        state = ensure_state_path(state, ['activate_versions', tap_stream_id])
-        state['activate_versions'][tap_stream_id] = {}
+    if 'versions' in state:
+        state = ensure_state_path(state, ['versions', tap_stream_id])
+        state['versions'][tap_stream_id] = {}
     return state
 
 def get_bookmark(state, tap_stream_id, key, default=None):

--- a/singer/state.py
+++ b/singer/state.py
@@ -47,14 +47,14 @@ def get_currently_syncing(state, default=None):
     return state.get('currently_syncing', default)
 
 def set_version(state, tap_stream_id, val):
-    state = ensure_state_path(state, ['activate_versions', tap_stream_id])
-    state['activate_versions'][tap_stream_id] = val
+    state = ensure_state_path(state, ['versions', tap_stream_id])
+    state['versions'][tap_stream_id] = val
     return state
 
 def clear_version(state, tap_stream_id):
-    state = ensure_state_path(state, ['activate_versions', tap_stream_id])
-    state['activate_versions'].pop(tap_stream_id, None)
+    state = ensure_state_path(state, ['versions', tap_stream_id])
+    state['versions'].pop(tap_stream_id, None)
     return state
 
 def get_version(state, tap_stream_id, default=None):
-    return state.get('activate_versions', {}).get(tap_stream_id, default)
+    return state.get('versions', {}).get(tap_stream_id, default)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -202,7 +202,7 @@ class TestCurrentlySyncing(unittest.TestCase):
         self.assertEqual(result, {'currently_syncing': 'bar'})
 
 
-class TestActivateVersion(unittest.TestCase):
+class TestVersions(unittest.TestCase):
     def test_empty_state(self):
         empty_state = {}
 
@@ -213,8 +213,8 @@ class TestActivateVersion(unittest.TestCase):
         self.assertEqual(st.get_version(empty_state, 'some_stream', 'default_value'),
                          'default_value')
 
-    def test_empty_activate_versions(self):
-        empty_versions = {'activate_versions':{}}
+    def test_empty_versions(self):
+        empty_versions = {'versions':{}}
 
         # Case with no value to fall back on
         self.assertIsNone(st.get_version(empty_versions, 'some_stream'))
@@ -228,7 +228,7 @@ class TestActivateVersion(unittest.TestCase):
         version_val_1 = 123456789
 
         non_empty_state = {
-            'activate_versions' : {
+            'versions' : {
                 stream_id_1 : version_val_1
             }
         }
@@ -260,12 +260,12 @@ class TestActivateVersion(unittest.TestCase):
         stream_id_1 = 'customers'
         version_val_1 = 123456789
 
-        result = st.set_version({'activate_versions': {stream_id_1: 'old-value'}}, stream_id_1, version_val_1)
-        self.assertEqual(result, {'activate_versions': {stream_id_1: version_val_1}})
+        result = st.set_version({'versions': {stream_id_1: 'old-value'}}, stream_id_1, version_val_1)
+        self.assertEqual(result, {'versions': {stream_id_1: version_val_1}})
 
     def test_clear_version(self):
         stream_id_1 = 'customers'
         version_val_1 = 123456789
 
-        result = st.clear_version({'activate_versions': {stream_id_1: version_val_1}}, stream_id_1)
-        self.assertEqual(result, {'activate_versions': {}})
+        result = st.clear_version({'versions': {stream_id_1: version_val_1}}, stream_id_1)
+        self.assertEqual(result, {'versions': {}})


### PR DESCRIPTION
# Description of change
Naming change to be more semantically accurate

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
